### PR TITLE
fix: Handle sigterm signal

### DIFF
--- a/src/greeter/greeter.cpp
+++ b/src/greeter/greeter.cpp
@@ -131,10 +131,12 @@ bool Greeter::initialize(WaylandClient &client) {
   return true;
 }
 
-int Greeter::run(WaylandClient &client) {
+int Greeter::run(WaylandClient &client,
+                 const std::atomic<bool> &shutdownRequested) {
   wl_display *display = client.display();
 
-  while (!m_exitRequested) {
+  while (!m_exitRequested &&
+         !shutdownRequested.load(std::memory_order_relaxed)) {
     client.repeatTick();
 
     if (client.flush() < 0) {

--- a/src/greeter/greeter.h
+++ b/src/greeter/greeter.h
@@ -3,6 +3,7 @@
 #include "greetd/greetd_client.h"
 #include "render/gl_shared_context.h"
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -22,7 +23,7 @@ public:
   ~Greeter();
 
   bool initialize(WaylandClient &client);
-  int run(WaylandClient &client);
+  int run(WaylandClient &client, const std::atomic<bool> &shutdownRequested);
 
   void onKeyboardEvent(std::uint32_t sym, std::uint32_t utf32,
                        std::uint32_t modifiers, bool pressed, bool preedit);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
 
   int result = 0;
   try {
-    result = greeter.run(client);
+    result = greeter.run(client, g_shutdownRequested);
   } catch (const std::exception &e) {
     kLog.error("fatal error in event loop: {}", e.what());
     result = 1;


### PR DESCRIPTION
Noticed during #6, the greeter was ignoring the SIGTERM command and only responded to `kill -s 9 <pid>`