### PR TITLE
fix: include string header

### DIFF
--- a/src/render/programs/wallpaper_program.cpp
+++ b/src/render/programs/wallpaper_program.cpp
@@ -1,6 +1,7 @@
 #include "render/programs/wallpaper_program.h"
 
 #include <stdexcept>
+#include <string>
 
 namespace {
 


### PR DESCRIPTION
On clang + libc++, build fails with the following error:

```
../src/render/programs/wallpaper_program.cpp:347:26: error: implicit instantiation of undefined template 'std::basic_string<char>'
  347 |   std::string fullFrag = std::string(kCommonFunctions) + fragSource;
      |                          ^
/usr/bin/../include/c++/v1/__fwd/string.h:43:7: note: template is declared here
   43 | class basic_string;
      |       ^
../src/render/programs/wallpaper_program.cpp:347:56: error: invalid operands to binary expression ('std::string' (aka 'basic_string<char>') and 'const char *')
  347 |   std::string fullFrag = std::string(kCommonFunctions) + fragSource;
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~
/usr/bin/../include/c++/v1/__iterator/reverse_iterator.h:298:1: note: candidate template ignored: could not match 'reverse_iterator<_Iter>' against 'const char *'
  298 | operator+(typename reverse_iterator<_Iter>::difference_type __n, const reverse_iterator<_Iter>& __x) {
      | ^
/usr/bin/../include/c++/v1/__iterator/wrap_iter.h:230:1: note: candidate template ignored: could not match '__wrap_iter<_Iter1>' against 'const char *'
  230 | operator+(typename __wrap_iter<_Iter1>::difference_type __n, __wrap_iter<_Iter1> __x) _NOEXCEPT {
      | ^
/usr/bin/../include/c++/v1/__iterator/move_iterator.h:317:1: note: candidate template ignored: could not match 'move_iterator<_Iter>' against 'const char *'
  317 | operator+(iter_difference_t<_Iter> __n, const move_iterator<_Iter>& __x)
      | ^
../src/render/programs/wallpaper_program.cpp:347:15: error: implicit instantiation of undefined template 'std::basic_string<char>'
  347 |   std::string fullFrag = std::string(kCommonFunctions) + fragSource;
      |               ^
/usr/bin/../include/c++/v1/__fwd/string.h:43:7: note: template is declared here
   43 | class basic_string;
      |       ^
```

This can quite trivially be solved by including `<string>` header in the affected file.