### PR TITLE
feat(compositor): impement vt switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Virtual terminal switching: `Ctrl+Alt+F1`–`F12` switches VTs from the greeter
+  (previously every key was forwarded to the UI with no VT handling).
 - Keyboard reference and a troubleshooting section in the README.
 - Configurable cursor theme, size and search path. The compositor now reads
   `cursor_theme`, `cursor_size` and `cursor_path` from `greeter.conf`, falling

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ The greeter works without a mouse.
 | `Esc` | Close menu or leave password step |
 | `F3` | Session picker |
 | `F7` | Color scheme picker |
+| `Ctrl+Alt+F1`–`F12` | Switch to virtual terminal (TTY) |
 
 ## Troubleshooting
 

--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -13,6 +13,7 @@
 #include <wayland-server-core.h>
 #include <wayland-server-protocol.h>
 #include <wlr/backend.h>
+#include <wlr/backend/session.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
@@ -32,6 +33,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
 
 #ifndef NOCTALIA_GREETER_INSTALLED_BINDIR
 #define NOCTALIA_GREETER_INSTALLED_BINDIR "/usr/local/bin"
@@ -77,6 +79,7 @@ struct greeter_view {
 struct greeter_server {
   struct wl_display *display;
   struct wlr_backend *backend;
+  struct wlr_session *session;
   struct wlr_renderer *renderer;
   struct wlr_allocator *allocator;
   struct wlr_scene *scene;
@@ -809,9 +812,26 @@ static void handle_keyboard_modifiers(struct wl_listener *listener,
 
 static void handle_keyboard_key(struct wl_listener *listener, void *data) {
   struct greeter_keyboard *keyboard = wl_container_of(listener, keyboard, key);
+  struct greeter_server *server = keyboard->server;
   struct wlr_keyboard_key_event *event = data;
-  wlr_seat_keyboard_notify_key(keyboard->server->seat, event->time_msec,
-                               event->keycode, event->state);
+
+  if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED && server->session != NULL) {
+    const xkb_keysym_t *syms;
+    int nsyms = xkb_state_key_get_syms(keyboard->wlr_keyboard->xkb_state,
+                                       event->keycode + 8, &syms);
+    for (int i = 0; i < nsyms; i++) {
+      xkb_keysym_t sym = syms[i];
+      if (sym >= (xkb_keysym_t)XKB_KEY_XF86Switch_VT_1 &&
+          sym <= (xkb_keysym_t)XKB_KEY_XF86Switch_VT_12) {
+        unsigned vt = (unsigned)(sym - (xkb_keysym_t)XKB_KEY_XF86Switch_VT_1 + 1);
+        wlr_session_change_vt(server->session, vt);
+        return;
+      }
+    }
+  }
+
+  wlr_seat_keyboard_notify_key(server->seat, event->time_msec, event->keycode,
+                               event->state);
 }
 
 static void handle_keyboard_destroy(struct wl_listener *listener, void *data) {
@@ -1106,8 +1126,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  server.backend =
-      wlr_backend_autocreate(wl_display_get_event_loop(server.display), NULL);
+  server.backend = wlr_backend_autocreate(
+      wl_display_get_event_loop(server.display), &server.session);
   if (server.backend == NULL) {
     fprintf(stderr, "failed to create wlroots backend\n");
     wl_display_destroy(server.display);


### PR DESCRIPTION
## Motivation

This change implements critical VT switching functionality. Currently, every key is being forwarded by the compositor to the UI, that makes it impossible to switch VT using standard Ctrl+Alt+F1 - F12

## Type of Change

Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated