### PR TITLE
Configure the keyboard for nixos users

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -48,16 +48,43 @@ in
         '';
       };
     };
+
+    settings.keyboard = {
+      layout = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "us";
+        description = "Keyboard layout for the greeter.";
+      };
+
+      variant = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "colemak";
+        description = "Keyboard variant for the greeter.";
+      };
+
+      options = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "grp:win_space_toggle";
+        description = "Keyboard options for the greeter.";
+      };
+    };
   };
 
   config =
     let
       user = config.services.greetd.settings.default_session.user;
       cursor = cfg.settings.cursor;
+      keyboard = cfg.settings.keyboard;
       cursorEnv =
         lib.optional (cursor.theme != null) "XCURSOR_THEME=${cursor.theme}"
         ++ lib.optional (cursor.size != null) "XCURSOR_SIZE=${toString cursor.size}"
-        ++ lib.optional (cursor.package != null) "XCURSOR_PATH=${cursor.package}/share/icons";
+        ++ lib.optional (cursor.package != null) "XCURSOR_PATH=${cursor.package}/share/icons"
+        ++ lib.optional (keyboard.layout != null) "XKB_DEFAULT_LAYOUT=${toString keyboard.layout}"
+        ++ lib.optional (keyboard.variant != null) "XKB_DEFAULT_VARIANT=${toString keyboard.variant}"
+        ++ lib.optional (keyboard.options != null) "XKB_DEFAULT_OPTIONS=${toString keyboard.options}";
       envPrefix = lib.optionalString (
         cursorEnv != [ ]
       ) "${pkgs.coreutils}/bin/env ${lib.concatStringsSep " " cursorEnv} ";

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -52,21 +52,21 @@ in
     settings.keyboard = {
       layout = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
-        default = null;
+        default = config.services.xserver.xkb.layout or null;
         example = "us";
         description = "Keyboard layout for the greeter.";
       };
 
       variant = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
-        default = null;
+        default = config.services.xserver.xkb.variant or null;
         example = "colemak";
         description = "Keyboard variant for the greeter.";
       };
 
       options = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
-        default = null;
+        default = config.services.xserver.xkb.options or null;
         example = "grp:win_space_toggle";
         description = "Keyboard options for the greeter.";
       };


### PR DESCRIPTION
Hello, thanks for this project.

This code add the ability to configure the keyboard config for Nixos users.

Example usage :
```nix
imports = [
    inputs.noctalia-greeter.nixosModules.default
];
programs.noctalia-greeter = {
    enable = true;
    package = inputs.noctalia-greeter.packages.${pkgs.stdenv.hostPlatform.system}.default;

    # Optional configuration
    greeter-args = "--session Niri --user myuser";
    settings = {
        cursor = {
            theme = "Adwaita";
            size = 24;
            package = pkgs.adwaita-icon-theme;
        };
        keyboard = {
            layout = "us";
            variant = "colemak";
            options = "grp:win_space_toggle";
        };
    };
};
`

