### PR TITLE
fix(nixos): wrap call to generateToml in a string interpolation to fix regression from #29

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -81,7 +81,7 @@ in
       }
       // lib.optionalAttrs (cfg.settings != { }) {
         "/var/lib/noctalia-greeter/greeter.toml".C = {
-          argument = generateToml "greeter.toml" cfg.settings;
+          argument = "${generateToml "greeter.toml" cfg.settings}";
           inherit user group;
           mode = "0644";
         };


### PR DESCRIPTION
Fixes a small regression in 77970b2643db7a33bb08e0710ec38e3464a1d4ad by wrapping the call to `generateToml` in a string interpolation.

<img width="1922" height="600" alt="image" src="https://github.com/user-attachments/assets/14518ddd-0325-4884-b184-87e8e0c4cc15" />
