### PR TITLE
fix(scripts): replace non-standard ripgrep with grep for PAM setup

### DIFF
--- a/scripts/setup_greetd_pam.sh
+++ b/scripts/setup_greetd_pam.sh
@@ -51,7 +51,7 @@ trap 'rm -f "${tmp}"' EXIT
 
 # Insert after last session line, or append.
 if grep -q -E "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}"; then
-  last_session="$(grep -n -E "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}" | tail -n 1 | awk -F: '{print $1}')"
+  last_session="$(grep -h -n -E "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}" | tail -n 1 | awk -F: '{print $1}')"
   awk -v line="${PAM_LINE}" -v last="${last_session}" '
     {
       print $0

--- a/scripts/setup_greetd_pam.sh
+++ b/scripts/setup_greetd_pam.sh
@@ -37,7 +37,7 @@ fi
 
 PAM_LINE="session    required     ${PAM_MODULE}"
 
-if rg -n "^[[:space:]]*session[[:space:]]+.*${PAM_MODULE}([[:space:]]|$)" "${PAM_FILE}" >/dev/null 2>&1; then
+if grep -q -E "^[[:space:]]*session[[:space:]]+.*${PAM_MODULE}([[:space:]]|$)" "${PAM_FILE}"; then
   echo "info: ${PAM_FILE} already contains ${PAM_MODULE}; nothing to do."
   exit 0
 fi
@@ -50,8 +50,8 @@ tmp="$(mktemp)"
 trap 'rm -f "${tmp}"' EXIT
 
 # Insert after last session line, or append.
-if rg -n "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}" >/dev/null 2>&1; then
-  last_session="$(rg -n "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}" | tail -n 1 | awk -F: '{print $1}')"
+if grep -q -E "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}"; then
+  last_session="$(grep -n -E "^[[:space:]]*session[[:space:]]+" "${PAM_FILE}" | tail -n 1 | awk -F: '{print $1}')"
   awk -v line="${PAM_LINE}" -v last="${last_session}" '
     {
       print $0


### PR DESCRIPTION
Avoid requiring `ripgrep` (rg) in the post-install/update hook, which caused the script to bypass the duplication check and append the PAM session module line on every package update/reinstallation.

Instead, use standard POSIX `grep -E` to perform the regex check and locate the insertion line number.

Resolves #36