### PR TITLE
feat(output): greeter.toml width/height mode override

### DIFF
--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -121,6 +121,8 @@ struct greeter_server {
   char** child_argv_ptr;
   char preferred_output[128];
   float manual_scale;
+  int manual_mode_width;
+  int manual_mode_height;
   char cursor_theme[128];
   int cursor_size;
   char cursor_path[512];
@@ -262,6 +264,8 @@ static void parse_output_layout_value(struct greeter_server* server, char* value
 static void read_greeter_config(struct greeter_server* server) {
   server->preferred_output[0] = '\0';
   server->manual_scale = 0.0f;
+  server->manual_mode_width = 0;
+  server->manual_mode_height = 0;
   server->cursor_theme[0] = '\0';
   server->cursor_size = 0;
   server->cursor_path[0] = '\0';
@@ -279,6 +283,12 @@ static void read_greeter_config(struct greeter_server* server) {
   }
   if (config.manual_scale >= 1.0f) {
     server->manual_scale = config.manual_scale;
+  }
+  if (config.manual_mode_width > 0) {
+    server->manual_mode_width = config.manual_mode_width;
+  }
+  if (config.manual_mode_height > 0) {
+    server->manual_mode_height = config.manual_mode_height;
   }
   if (config.cursor_theme[0] != '\0') {
     snprintf(server->cursor_theme, sizeof(server->cursor_theme), "%s", config.cursor_theme);
@@ -622,7 +632,24 @@ static void disable_output(struct greeter_output* output) {
   }
 }
 
-static struct wlr_output_mode* select_output_mode(struct wlr_output* wlr_output) {
+static struct wlr_output_mode* select_output_mode(struct wlr_output* wlr_output, int manual_width, int manual_height) {
+  if (manual_width > 0 && manual_height > 0) {
+    struct wlr_output_mode* best = NULL;
+    struct wlr_output_mode* mode;
+    wl_list_for_each(mode, &wlr_output->modes, link) {
+      if (mode->width != manual_width || mode->height != manual_height) {
+        continue;
+      }
+      if (best == NULL || mode->refresh > best->refresh) {
+        best = mode;
+      }
+    }
+    if (best != NULL) {
+      return best;
+    }
+    wlr_log(WLR_INFO, "no mode %dx%d for %s; falling back to preferred", manual_width, manual_height, wlr_output->name);
+  }
+
   struct wlr_output_mode* preferred = wlr_output_preferred_mode(wlr_output);
   if (preferred == NULL) {
     return NULL;
@@ -656,12 +683,13 @@ static bool commit_output_enabled(struct greeter_output* output) {
   struct wlr_output_state state;
   wlr_output_state_init(&state);
   wlr_output_state_set_enabled(&state, true);
-  struct wlr_output_mode* mode = select_output_mode(output->wlr_output);
+  struct wlr_output_mode* mode =
+      select_output_mode(output->wlr_output, server->manual_mode_width, server->manual_mode_height);
   if (mode != NULL) {
     wlr_output_state_set_mode(&state, mode);
     wlr_log(WLR_INFO, "selected output mode: %dx%d @ %.3f Hz", mode->width, mode->height, mode->refresh / 1000.0);
   }
-  const float scale = output_ui_scale(output->wlr_output, output->server->manual_scale);
+  const float scale = output_ui_scale(output->wlr_output, server->manual_scale);
   wlr_output_state_set_scale(&state, scale);
   bool ok = wlr_output_commit_state(output->wlr_output, &state);
   wlr_output_state_finish(&state);

--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -633,6 +633,9 @@ static void disable_output(struct greeter_output* output) {
 }
 
 static struct wlr_output_mode* select_output_mode(struct wlr_output* wlr_output, int manual_width, int manual_height) {
+  if ((manual_width > 0) != (manual_height > 0)) {
+    wlr_log(WLR_INFO, "output width/height require both values; ignoring partial manual mode for %s", wlr_output->name);
+  }
   if (manual_width > 0 && manual_height > 0) {
     struct wlr_output_mode* best = NULL;
     struct wlr_output_mode* mode;

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -160,9 +160,17 @@ namespace {
               kLog.warn("{}: invalid output.scale value", path.string());
             }
           } else if (entryView == "width") {
-            config.outputModeWidth = modeDimensionValue(entryNode);
+            if (const auto width = modeDimensionValue(entryNode)) {
+              config.outputModeWidth = *width;
+            } else {
+              kLog.warn("{}: invalid output.width value", path.string());
+            }
           } else if (entryView == "height") {
-            config.outputModeHeight = modeDimensionValue(entryNode);
+            if (const auto height = modeDimensionValue(entryNode)) {
+              config.outputModeHeight = *height;
+            } else {
+              kLog.warn("{}: invalid output.height value", path.string());
+            }
           }
         } else if (keyView == "cursor") {
           if (!isKnownCursorKey(entryView)) {

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -35,7 +35,7 @@ namespace {
   }
 
   [[nodiscard]] bool isKnownOutputKey(std::string_view key) {
-    return key == "name" || key == "layout" || key == "scale";
+    return key == "name" || key == "layout" || key == "scale" || key == "width" || key == "height";
   }
 
   [[nodiscard]] bool isKnownCursorKey(std::string_view key) { return key == "theme" || key == "size" || key == "path"; }
@@ -69,6 +69,15 @@ namespace {
   [[nodiscard]] std::optional<int> cursorSizeValue(const toml::node& node) {
     if (const auto value = node.value<int64_t>()) {
       if (*value > 0 && *value <= 1024) {
+        return static_cast<int>(*value);
+      }
+    }
+    return std::nullopt;
+  }
+
+  [[nodiscard]] std::optional<int> modeDimensionValue(const toml::node& node) {
+    if (const auto value = node.value<int64_t>()) {
+      if (*value > 0 && *value <= 16384) {
         return static_cast<int>(*value);
       }
     }
@@ -144,10 +153,16 @@ namespace {
             config.outputName = stringValue(entryNode);
           } else if (entryView == "layout") {
             config.outputLayout = stringValue(entryNode);
-          } else if (const auto scale = positiveFloatValue(entryNode)) {
-            config.outputScale = *scale;
-          } else {
-            kLog.warn("{}: invalid output.scale value", path.string());
+          } else if (entryView == "scale") {
+            if (const auto scale = positiveFloatValue(entryNode)) {
+              config.outputScale = *scale;
+            } else {
+              kLog.warn("{}: invalid output.scale value", path.string());
+            }
+          } else if (entryView == "width") {
+            config.outputModeWidth = modeDimensionValue(entryNode);
+          } else if (entryView == "height") {
+            config.outputModeHeight = modeDimensionValue(entryNode);
           }
         } else if (keyView == "cursor") {
           if (!isKnownCursorKey(entryView)) {
@@ -369,7 +384,8 @@ namespace greeter::config {
     std::ostringstream out;
     out << "# noctalia-greeter greeter.toml\n";
     out << "# [session] default/last, [user] default, [appearance] scheme/password_style/hide_logo\n";
-    out << "# [output] name/layout/scale, [cursor] theme/size/path, [keyboard] layout/variant/options/numlock\n";
+    out << "# [output] name/layout/scale/width/height, [cursor] theme/size/path\n";
+    out << "# [keyboard] layout/variant/options/numlock\n";
     out << "# [auth] allow_empty_password (bool, default false; enables fingerprint/smartcard PAM auth)\n";
     out << '\n';
     out << formatToml(table);
@@ -414,6 +430,12 @@ extern "C" void greeter_compositor_config_load(const char* state_dir, struct gre
 
   if (config.outputScale.has_value() && *config.outputScale >= 1.0f) {
     out->manual_scale = *config.outputScale;
+  }
+  if (config.outputModeWidth.has_value() && *config.outputModeWidth > 0) {
+    out->manual_mode_width = *config.outputModeWidth;
+  }
+  if (config.outputModeHeight.has_value() && *config.outputModeHeight > 0) {
+    out->manual_mode_height = *config.outputModeHeight;
   }
   if (config.cursorSize.has_value() && *config.cursorSize > 0) {
     out->cursor_size = *config.cursorSize;

--- a/src/greeter/greeter_config_io.h
+++ b/src/greeter/greeter_config_io.h
@@ -9,6 +9,8 @@ extern "C" {
 struct greeter_compositor_config {
   char preferred_output[128];
   float manual_scale;
+  int manual_mode_width;
+  int manual_mode_height;
   char cursor_theme[128];
   int cursor_size;
   char cursor_path[512];

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -19,6 +19,8 @@ namespace greeter::config {
     std::optional<std::string> outputName;
     std::optional<std::string> outputLayout;
     std::optional<float> outputScale;
+    std::optional<int> outputModeWidth;
+    std::optional<int> outputModeHeight;
 
     std::optional<std::string> cursorTheme;
     std::optional<int> cursorSize;


### PR DESCRIPTION
## Summary

- Add optional `[output] width` and `[output] height` keys to `greeter.toml`
- Compositor picks the highest-refresh DRM mode matching that size, falling back to the EDID preferred mode when unavailable
- Fix `output.scale` parsing so only the `scale` key is treated as a scale value (other output keys were previously mis-parsed)

## Motivation

On some setups the greeter compositor modesets to a different resolution/refresh than the desktop session, causing a visible blank/flash at login. Pinning the greeter mode to match the session avoids that transition.

Fixes #53

## Example

```toml
[output]
name = "DP-2"
scale = 1.5
width = 5120
height = 2160
```

## Test plan

- [ ] Greeter starts with configured mode when size is advertised
- [ ] Falls back cleanly when width/height are absent or unavailable
- [ ] Login transition no longer modesets when greeter and session modes match