### PR TITLE
feat(output): per-output DRM transform for portrait monitors

### DIFF
--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -100,6 +100,11 @@ struct greeter_output_placement {
   int y;
 };
 
+struct greeter_output_transform {
+  char name[128];
+  enum wl_output_transform transform;
+};
+
 struct greeter_server {
   struct wl_display* display;
   struct wlr_backend* backend;
@@ -141,6 +146,8 @@ struct greeter_server {
   float manual_scale;
   int manual_mode_width;
   int manual_mode_height;
+  struct greeter_output_transform output_transforms[16];
+  size_t output_transform_count;
   int idle_timeout_sec;
   struct timespec last_activity;
   int idle_timerfd;
@@ -284,11 +291,112 @@ static void parse_output_layout_value(struct greeter_server* server, char* value
   }
 }
 
+static bool parse_transform_token(const char* token, enum wl_output_transform* out) {
+  if (token == NULL || token[0] == '\0' || out == NULL) {
+    return false;
+  }
+  if (strcmp(token, "normal") == 0 || strcmp(token, "0") == 0 || strcmp(token, "none") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_NORMAL;
+    return true;
+  }
+  if (strcmp(token, "90") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_90;
+    return true;
+  }
+  if (strcmp(token, "180") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_180;
+    return true;
+  }
+  if (strcmp(token, "270") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_270;
+    return true;
+  }
+  if (strcmp(token, "flipped") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_FLIPPED;
+    return true;
+  }
+  if (strcmp(token, "flipped-90") == 0 || strcmp(token, "flipped_90") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_FLIPPED_90;
+    return true;
+  }
+  if (strcmp(token, "flipped-180") == 0 || strcmp(token, "flipped_180") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_FLIPPED_180;
+    return true;
+  }
+  if (strcmp(token, "flipped-270") == 0 || strcmp(token, "flipped_270") == 0) {
+    *out = WL_OUTPUT_TRANSFORM_FLIPPED_270;
+    return true;
+  }
+  return false;
+}
+
+static bool parse_output_transform_entry(const char* token, struct greeter_output_transform* out) {
+  char buf[256];
+  snprintf(buf, sizeof(buf), "%s", token);
+  char* colon = strrchr(buf, ':');
+  if (colon == NULL || colon == buf) {
+    return false;
+  }
+  *colon = '\0';
+  char* name = trim(buf);
+  char* transform_raw = trim(colon + 1);
+  if (name[0] == '\0' || transform_raw[0] == '\0') {
+    return false;
+  }
+  enum wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
+  if (!parse_transform_token(transform_raw, &transform)) {
+    return false;
+  }
+  snprintf(out->name, sizeof(out->name), "%s", name);
+  out->transform = transform;
+  return true;
+}
+
+static void parse_output_transforms_value(struct greeter_server* server, char* value) {
+  server->output_transform_count = 0;
+  for (char* p = value; *p != '\0'; ++p) {
+    if (*p == ';') {
+      *p = ' ';
+    }
+  }
+
+  char* saveptr = NULL;
+  for (char* token = strtok_r(value, " \t", &saveptr); token != NULL; token = strtok_r(NULL, " \t", &saveptr)) {
+    if (server->output_transform_count >= sizeof(server->output_transforms) / sizeof(server->output_transforms[0])) {
+      wlr_log(
+          WLR_ERROR, "output_transforms: too many entries (max %zu)",
+          sizeof(server->output_transforms) / sizeof(server->output_transforms[0])
+      );
+      break;
+    }
+    struct greeter_output_transform entry;
+    if (!parse_output_transform_entry(token, &entry)) {
+      wlr_log(WLR_ERROR, "output_transforms: invalid entry '%s' (use NAME:90)", token);
+      continue;
+    }
+    server->output_transforms[server->output_transform_count++] = entry;
+    wlr_log(WLR_INFO, "output transform: %s -> %d", entry.name, (int)entry.transform);
+  }
+}
+
+static enum wl_output_transform transform_for_output(const struct greeter_server* server, const char* name) {
+  if (name == NULL || name[0] == '\0') {
+    return WL_OUTPUT_TRANSFORM_NORMAL;
+  }
+  for (size_t i = 0; i < server->output_transform_count; ++i) {
+    if (strcmp(server->output_transforms[i].name, name) == 0) {
+      return server->output_transforms[i].transform;
+    }
+  }
+  return WL_OUTPUT_TRANSFORM_NORMAL;
+}
+
 static void read_greeter_config(struct greeter_server* server) {
   server->preferred_output[0] = '\0';
   server->manual_scale = 0.0f;
   server->manual_mode_width = 0;
   server->manual_mode_height = 0;
+  server->output_transform_count = 0;
   server->idle_timeout_sec = 0;
   server->cursor_theme[0] = '\0';
   server->cursor_size = 0;
@@ -362,6 +470,11 @@ static void read_greeter_config(struct greeter_server* server) {
     char layout[2048];
     snprintf(layout, sizeof(layout), "%s", config.output_layout);
     parse_output_layout_value(server, layout);
+  }
+  if (config.output_transforms[0] != '\0') {
+    char transforms[2048];
+    snprintf(transforms, sizeof(transforms), "%s", config.output_transforms);
+    parse_output_transforms_value(server, transforms);
   }
 }
 
@@ -864,6 +977,8 @@ static bool commit_output_enabled(struct greeter_output* output) {
     wlr_output_state_set_mode(&state, mode);
     wlr_log(WLR_INFO, "selected output mode: %dx%d @ %.3f Hz", mode->width, mode->height, mode->refresh / 1000.0);
   }
+  const enum wl_output_transform transform = transform_for_output(server, output->wlr_output->name);
+  wlr_output_state_set_transform(&state, transform);
   const float scale = output_ui_scale(output->wlr_output, server->manual_scale);
   wlr_output_state_set_scale(&state, scale);
   bool ok = wlr_output_commit_state(output->wlr_output, &state);
@@ -873,7 +988,7 @@ static bool commit_output_enabled(struct greeter_output* output) {
     return false;
   }
 
-  wlr_log(WLR_INFO, "output %s scale=%.2f", output->wlr_output->name, scale);
+  wlr_log(WLR_INFO, "output %s scale=%.2f transform=%d", output->wlr_output->name, scale, (int)transform);
   return true;
 }
 

--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -332,7 +332,13 @@ static bool parse_transform_token(const char* token, enum wl_output_transform* o
 
 static bool parse_output_transform_entry(const char* token, struct greeter_output_transform* out) {
   char buf[256];
-  snprintf(buf, sizeof(buf), "%s", token);
+  if (token == NULL || out == NULL) {
+    return false;
+  }
+  const int token_len = snprintf(buf, sizeof(buf), "%s", token);
+  if (token_len < 0 || (size_t)token_len >= sizeof(buf)) {
+    return false;
+  }
   char* colon = strrchr(buf, ':');
   if (colon == NULL || colon == buf) {
     return false;
@@ -347,7 +353,10 @@ static bool parse_output_transform_entry(const char* token, struct greeter_outpu
   if (!parse_transform_token(transform_raw, &transform)) {
     return false;
   }
-  snprintf(out->name, sizeof(out->name), "%s", name);
+  const int name_len = snprintf(out->name, sizeof(out->name), "%s", name);
+  if (name_len < 0 || (size_t)name_len >= sizeof(out->name)) {
+    return false;
+  }
   out->transform = transform;
   return true;
 }

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -36,7 +36,12 @@ namespace {
   }
 
   [[nodiscard]] bool isKnownOutputKey(std::string_view key) {
-    return key == "name" || key == "layout" || key == "scale" || key == "width" || key == "height";
+    return key == "name"
+        || key == "layout"
+        || key == "scale"
+        || key == "width"
+        || key == "height"
+        || key == "transforms";
   }
 
   [[nodiscard]] bool isKnownIdleKey(std::string_view key) { return key == "timeout"; }
@@ -183,6 +188,8 @@ namespace {
             } else {
               kLog.warn("{}: invalid output.height value", path.string());
             }
+          } else if (entryView == "transforms") {
+            config.outputTransforms = stringValue(entryNode);
           }
         } else if (keyView == "idle") {
           if (!isKnownIdleKey(entryView)) {
@@ -318,6 +325,12 @@ namespace {
     if (config.outputModeHeight.has_value()) {
       output.insert_or_assign("height", static_cast<int64_t>(*config.outputModeHeight));
     }
+    insertString(
+        output, "transforms", config.outputTransforms,
+        [](toml::table& table, std::string_view key, const std::string& value) {
+          table.insert_or_assign(std::string(key), value);
+        }
+    );
     if (!output.empty()) {
       root.insert("output", std::move(output));
     }
@@ -428,7 +441,7 @@ namespace greeter::config {
     std::ostringstream out;
     out << "# noctalia-greeter greeter.toml\n";
     out << "# [session] default/last, [user] default, [appearance] scheme/password_style/hide_logo\n";
-    out << "# [output] name/layout/scale/width/height, [idle] timeout, [cursor] theme/size/path\n";
+    out << "# [output] name/layout/scale/width/height/transforms, [idle] timeout, [cursor] theme/size/path\n";
     out << "# [keyboard] layout/variant/options/numlock\n";
     out << "# [auth] allow_empty_password (bool, default false; enables fingerprint/smartcard PAM auth)\n";
     out << '\n';
@@ -471,6 +484,7 @@ extern "C" void greeter_compositor_config_load(const char* state_dir, struct gre
     out->keyboard_numlock = *config.keyboardNumlock ? 1 : -1;
   }
   copyString(out->output_layout, sizeof(out->output_layout), config.outputLayout);
+  copyString(out->output_transforms, sizeof(out->output_transforms), config.outputTransforms);
 
   if (config.outputScale.has_value() && *config.outputScale >= 1.0f) {
     out->manual_scale = *config.outputScale;

--- a/src/greeter/greeter_config_io.h
+++ b/src/greeter/greeter_config_io.h
@@ -11,6 +11,7 @@ struct greeter_compositor_config {
   float manual_scale;
   int manual_mode_width;
   int manual_mode_height;
+  char output_transforms[2048];
   int idle_timeout_sec;
   char cursor_theme[128];
   int cursor_size;

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -21,6 +21,8 @@ namespace greeter::config {
     std::optional<float> outputScale;
     std::optional<int> outputModeWidth;
     std::optional<int> outputModeHeight;
+    // Per-output DRM transforms: "NAME:90; NAME2:180" (see compositor parse).
+    std::optional<std::string> outputTransforms;
 
     std::optional<int> idleTimeoutSec;
 


### PR DESCRIPTION
## Summary

- Add `[output].transforms` to `greeter.toml` for per-connector DRM rotation
- Greeter compositor applies `wlr_output_state_set_transform` when enabling outputs
- Portrait / rotated panels can show upright login UI (fixes #60)
- Persist `[output].width` / `height` on config write (same admin-key round-trip issue)

## Config

```toml
[output]
# optional: pin greeter to the portrait panel only
# name = "HDMI-A-1"
transforms = "HDMI-A-1:90"
```

Connector names from a running session:

```sh
noctalia-greeter outputs
```

Supported transform tokens: `normal`/`0`/`none`, `90`, `180`, `270`, `flipped`, `flipped-90`, `flipped-180`, `flipped-270`.

Multiple outputs: `transforms = "DP-1:normal; HDMI-A-1:90"`.

## Notes

- Transform is independent of `[output].width`/`height` (those select the physical DRM mode size)
- Scale is unchanged (`[output].scale` or auto)
- Shell Sync Now still only copies layout positions, not transforms — set transforms by hand for now

## Test plan

- [ ] Multi-monitor with one panel at 90°: greeter UI upright on that panel
- [ ] Landscape-only setup with no `transforms`: unchanged
- [ ] Invalid token logs error and leaves that connector at normal
- [ ] Session/scheme save does not drop `transforms` from greeter.toml
- [ ] Restart greetd after config change: `sudo systemctl restart greetd`