### PR TITLE
feat(appearance): load per-output synced wallpapers

### DIFF
--- a/src/greeter/appearance_config.cpp
+++ b/src/greeter/appearance_config.cpp
@@ -86,26 +86,47 @@ std::optional<GreeterSyncedAppearance> loadGreeterSyncedAppearance() {
       return std::nullopt;
     }
 
-    const auto wallpaperIt = root.find("wallpaper");
-    if (wallpaperIt != root.end() && wallpaperIt->is_object()) {
-      const auto& wallpaper = *wallpaperIt;
+    const auto parseWallpaperObject = [](const nlohmann::json& wallpaper, GreeterOutputWallpaper& out) {
       if (const auto pathValue = wallpaper.find("path"); pathValue != wallpaper.end() && pathValue->is_string()) {
-        appearance.wallpaperPath = pathValue->get<std::string>();
+        out.path = pathValue->get<std::string>();
       }
       if (const auto fillMode = wallpaper.find("fill_mode"); fillMode != wallpaper.end() && fillMode->is_string()) {
         if (const auto parsed = greeter::appearance::parseFillMode(fillMode->get<std::string>())) {
-          appearance.wallpaperFillMode = *parsed;
+          out.fillMode = *parsed;
         }
       }
       if (const auto fillColor = wallpaper.find("fill_color"); fillColor != wallpaper.end() && fillColor->is_string()) {
         Color color;
         if (tryParseHexColor(fillColor->get<std::string>(), color)) {
-          appearance.wallpaperFillColor = color;
+          out.fillColor = color;
         }
-      } else if (!appearance.wallpaperPath.empty()) {
+      } else if (!out.path.empty()) {
         Color color;
-        if (parseColorWallpaperPath(appearance.wallpaperPath, color)) {
-          appearance.wallpaperFillColor = color;
+        if (parseColorWallpaperPath(out.path, color)) {
+          out.fillColor = color;
+        }
+      }
+    };
+
+    const auto wallpaperIt = root.find("wallpaper");
+    if (wallpaperIt != root.end() && wallpaperIt->is_object()) {
+      GreeterOutputWallpaper single;
+      parseWallpaperObject(*wallpaperIt, single);
+      appearance.wallpaperPath = single.path;
+      appearance.wallpaperFillMode = single.fillMode;
+      appearance.wallpaperFillColor = single.fillColor;
+    }
+
+    const auto wallpapersIt = root.find("wallpapers");
+    if (wallpapersIt != root.end() && wallpapersIt->is_object()) {
+      for (const auto& [connector, value] : wallpapersIt->items()) {
+        if (!value.is_object() || connector.empty()) {
+          continue;
+        }
+        GreeterOutputWallpaper entry;
+        parseWallpaperObject(value, entry);
+        if (!entry.path.empty()) {
+          appearance.wallpapersByOutput.emplace(connector, std::move(entry));
         }
       }
     }

--- a/src/greeter/appearance_config.h
+++ b/src/greeter/appearance_config.h
@@ -6,8 +6,15 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 
 struct Color;
+
+struct GreeterOutputWallpaper {
+  std::string path;
+  WallpaperFillMode fillMode = WallpaperFillMode::Crop;
+  Color fillColor = rgba(0.0f, 0.0f, 0.0f, 0.0f);
+};
 
 struct GreeterSyncedAppearance {
   Palette palette{};
@@ -15,7 +22,23 @@ struct GreeterSyncedAppearance {
   std::string wallpaperPath;
   WallpaperFillMode wallpaperFillMode = WallpaperFillMode::Crop;
   Color wallpaperFillColor = rgba(0.0f, 0.0f, 0.0f, 0.0f);
+  // connector name -> wallpaper (from appearance.json "wallpapers")
+  std::unordered_map<std::string, GreeterOutputWallpaper> wallpapersByOutput;
   float cornerRadiusScale = 1.0f;
+
+  [[nodiscard]] GreeterOutputWallpaper wallpaperForOutput(std::string_view outputName) const {
+    if (!outputName.empty()) {
+      const auto it = wallpapersByOutput.find(std::string(outputName));
+      if (it != wallpapersByOutput.end() && !it->second.path.empty()) {
+        return it->second;
+      }
+    }
+    GreeterOutputWallpaper fallback;
+    fallback.path = wallpaperPath;
+    fallback.fillMode = wallpaperFillMode;
+    fallback.fillColor = wallpaperFillColor;
+    return fallback;
+  }
 };
 
 [[nodiscard]] std::filesystem::path greeterAppearanceConfigPath();

--- a/src/greeter/appearance_config.h
+++ b/src/greeter/appearance_config.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 struct Color;
 

--- a/src/greeter/appearance_sync.cpp
+++ b/src/greeter/appearance_sync.cpp
@@ -19,11 +19,14 @@ namespace greeter::appearance {
     constexpr mode_t kSyncedFileMode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 
     [[nodiscard]] bool isWallpaperFileName(std::string_view name) {
+      // wallpaper, wallpaper.webp, wallpaper-DP-2.webp, wallpaper-HDMI-A-1.jpg
       if (name == kWallpaperBaseName) {
         return true;
       }
-      constexpr std::string_view kPrefix = "wallpaper.";
-      return name.size() > kPrefix.size() && name.substr(0, kPrefix.size()) == kPrefix;
+      constexpr std::string_view kDot = "wallpaper.";
+      constexpr std::string_view kDash = "wallpaper-";
+      return (name.size() > kDot.size() && name.substr(0, kDot.size()) == kDot)
+          || (name.size() > kDash.size() && name.substr(0, kDash.size()) == kDash);
     }
 
     [[nodiscard]] bool setMode(const std::filesystem::path& path, mode_t mode, std::string& errorOut) {

--- a/src/greeter/greeter.cpp
+++ b/src/greeter/greeter.cpp
@@ -251,6 +251,7 @@ void Greeter::syncOutputWindows() {
 
     const std::size_t index = m_views.size();
     view.window->bindOutput(targets[index]->output);
+    view.surface->setBoundOutputName(targets[index]->name);
     kLog.info("greeter view for output '{}'", targets[index]->name.empty() ? "?" : targets[index]->name.c_str());
 
     if (!m_views.empty()) {
@@ -275,6 +276,7 @@ void Greeter::syncOutputWindows() {
 
   for (std::size_t i = 0; i < targets.size(); ++i) {
     m_views[i].window->bindOutput(targets[i]->output);
+    m_views[i].surface->setBoundOutputName(targets[i]->name);
     m_views[i].window->matchOutputLogicalSize();
     if (m_sceneReady) {
       m_views[i].window->setSceneReady(true);

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -1599,7 +1599,20 @@ std::optional<std::size_t> GreeterSurface::findSchemeIndex(const std::string_vie
   return std::nullopt;
 }
 
+void GreeterSurface::setBoundOutputName(std::string outputName) {
+  if (m_boundOutputName == outputName) {
+    return;
+  }
+  m_boundOutputName = std::move(outputName);
+  // Re-resolve synced wallpaper for this connector after binding.
+  if (isSyncedScheme(m_selectedScheme)) {
+    applyScheme(m_selectedScheme);
+    requestLayout();
+  }
+}
+
 void GreeterSurface::clearWallpaperDisplay() {
+
   m_hasSyncedWallpaper = false;
   m_wallpaperPath.clear();
   m_wallpaperFillMode = WallpaperFillMode::Crop;
@@ -1626,9 +1639,10 @@ void GreeterSurface::applyScheme(const std::size_t schemeIndex) {
 
     setPalette(m_syncedAppearance->palette);
     Style::setCornerRadiusScale(m_syncedAppearance->cornerRadiusScale);
-    m_wallpaperPath = m_syncedAppearance->wallpaperPath;
-    m_wallpaperFillMode = m_syncedAppearance->wallpaperFillMode;
-    m_wallpaperFillColor = m_syncedAppearance->wallpaperFillColor;
+    const auto wallpaper = m_syncedAppearance->wallpaperForOutput(m_boundOutputName);
+    m_wallpaperPath = wallpaper.path;
+    m_wallpaperFillMode = wallpaper.fillMode;
+    m_wallpaperFillColor = wallpaper.fillColor;
     m_hasSyncedWallpaper = !m_wallpaperPath.empty();
     m_wallpaperDirty = true;
     return;

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -43,6 +43,7 @@ public:
   void initialize(RenderContext* context);
 
   void setWindow(GreeterWindow* window);
+  void setBoundOutputName(std::string outputName);
   void setGreetdClient(GreetdClient* client);
   void setUsername(const std::string& username);
   void setOnExitRequested(std::function<void()> callback);
@@ -229,6 +230,7 @@ private:
   TextureHandle m_headerAvatarTexture{};
   TextureHandle m_wallpaperTexture{};
   std::string m_loadedHeaderAvatarPath;
+  std::string m_boundOutputName;
   std::string m_wallpaperPath;
   WallpaperFillMode m_wallpaperFillMode = WallpaperFillMode::Crop;
   Color m_wallpaperFillColor = rgba(0.0f, 0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
## Summary

Load the optional `wallpapers` map from synced `appearance.json` and select wallpaper **per greeter view** by the bound DRM connector name. Falls back to the legacy single `wallpaper.path` for older shell sync output.

Pairs with noctalia-shell staging of `wallpaper-<connector>.*` (see companion shell PR).

### Behavior

```json
{
  "wallpaper": { "path": ".../wallpaper.jpeg", "fill_mode": "crop" },
  "wallpapers": {
    "DP-2": { "path": ".../wallpaper-DP-2.jpeg", "fill_mode": "crop" },
    "HDMI-A-1": { "path": ".../wallpaper-HDMI-A-1.webp", "fill_mode": "crop" }
  }
}
```

- Each greeter surface calls `wallpaperForOutput(boundOutputName)`
- Missing connector or empty map → legacy `wallpaper` field
- Installer/apply helper accepts `wallpaper-*` staged files

### Notes

- Independent of output transform (`[output].transforms`); can land separately
- Pin (`[output].name`) still controls which heads run the greeter; multi-head interactive layout is separate work

## Test plan

- [ ] Shell Sync Now stages map → greeter on pin DP-2 shows DP-2 image
- [ ] Pin HDMI-A-1 shows HDMI-A-1 image
- [ ] Appearance without `wallpapers` → legacy single wallpaper still works
- [ ] Session login / scheme selection unchanged