### PR TITLE
fix(nix): add missing system buildInputs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,9 +20,22 @@
   glib,
   librsvg,
   jemalloc,
+  tomlplusplus,
+  nlohmann_json,
+  stb,
+  fetchFromGitHub,
 }: let
   inherit (builtins) head match readFile;
   version = head (match ".*version: '([^']+)'.*" (readFile ../meson.build));
+  stb' = stb.overrideAttrs (_: {
+    version = "unstable-2025-10-26";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
+    };
+  });
 in
   stdenv.mkDerivation {
     pname = "noctalia-greeter";
@@ -58,8 +71,10 @@ in
       libwebp
       glib
       librsvg
+      tomlplusplus
+      nlohmann_json
+      stb'
     ];
-
 
     mesonBuildType = "release";
 


### PR DESCRIPTION
Fixes a build regression in Nix introduced in 231c132002916df904bf1d2bbda2c980cd6a208e. Uses stb' from <https://github.com/noctalia-dev/noctalia/blob/main/nix/package.nix>.
