### PR TITLE
fix(polkit): use absolute path in exec.path annotation

### DIFF
--- a/data/org.noctalia.greeter.apply-appearance.policy.in
+++ b/data/org.noctalia.greeter.apply-appearance.policy.in
@@ -11,7 +11,7 @@
       <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">noctalia-greeter-apply-appearance</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">@bindir@/noctalia-greeter-apply-appearance</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 </policyconfig>

--- a/meson.build
+++ b/meson.build
@@ -252,8 +252,13 @@ executable('noctalia-greeter-apply-appearance',
   install: true,
 )
 
-install_data(
-  'data/org.noctalia.greeter.apply-appearance.policy',
+configure_file(
+  input: 'data/org.noctalia.greeter.apply-appearance.policy.in',
+  output: 'org.noctalia.greeter.apply-appearance.policy',
+  configuration: {
+    'bindir': get_option('prefix') / get_option('bindir'),
+  },
+  install: true,
   install_dir: get_option('datadir') / 'polkit-1' / 'actions',
 )
 


### PR DESCRIPTION
[polkit requires org.freedesktop.policykit.exec.path to be the absolute path of the target program](https://www.freedesktop.org/software/polkit/docs/latest/pkexec.1.html?__goaway_challenge=meta-refresh&__goaway_id=7b43f6ab5fb46188d69be146baeb36aa&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#:~:text=value%20set%20to%20the%20full%20path%20of%20the%20program) so the current bare name of the program never matches, resulting in a generic prompt instead of the one specified in the policy, and allow_gui is lost

this PR changes the policy to a template and substitutes the install bin dir in the path so pkexec can resolve it correctly