### PR TITLE
feat: add PAM-backed autologin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ It is built for **greetd**: greetd starts the bundled wlroots compositor (`nocta
 
 Pair it with **[Noctalia v5](https://github.com/noctalia-dev/noctalia)** if you want wallpaper and palette synced from the shell settings (optional).
 
+## PAM autologin
+
+To have the greeter authenticate a configured account immediately, set both values below:
+
+```toml
+[user]
+default = "your-user"
+
+[auth]
+autologin = true
+```
+
+This is authenticated autologin: the greeter calls greetd's normal `create_session`
+flow, so PAM modules such as `pam_systemd_loadkey` and `pam_gnome_keyring` can use a
+LUKS passphrase retained by the systemd initrd. It never submits an empty password.
+If PAM asks for input or rejects the login, the normal password screen remains available.
+
 ## Dependencies
 
 Install everything below on the machine where greetd will run. Each list covers build tools and libraries, plus **greetd** and **D-Bus** (used by `noctalia-greeter-session`). You still need your desktop sessions separately (niri, Hyprland, and so on).

--- a/examples/greeter.toml
+++ b/examples/greeter.toml
@@ -101,3 +101,7 @@ numlock = true
 [auth]
 # Allow empty password submit (fprintd / smartcard PAM). Default false.
 allow_empty_password = false
+# Authenticate [user].default immediately. This runs greetd's PAM stack, so
+# pam_systemd_loadkey can unlock a matching GNOME Keyring after LUKS. If PAM
+# asks for input or authentication fails, the normal password screen is shown.
+autologin = false

--- a/src/greeter/greeter.cpp
+++ b/src/greeter/greeter.cpp
@@ -243,6 +243,7 @@ void Greeter::syncOutputWindows() {
     View view;
     view.surface = std::make_unique<GreeterSurface>();
     view.surface->setGreetdClient(&m_greetdClient);
+    view.surface->setAutoLoginAllowed(m_views.empty());
     view.surface->setOnExitRequested([this]() { m_exitRequested = true; });
     view.surface->setOnStateChanged([this](GreeterSurface* source) { syncStateFrom(source); });
     view.surface->initialize(m_renderContext.get());

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -20,9 +20,8 @@ namespace {
 
   void recordParseError(const std::filesystem::path& path, const toml::parse_error& error) {
     const auto source = error.source();
-    const auto existing = std::ranges::find_if(g_diagnostics, [&path](const auto& diagnostic) {
-      return diagnostic.path == path;
-    });
+    const auto existing =
+        std::ranges::find_if(g_diagnostics, [&path](const auto& diagnostic) { return diagnostic.path == path; });
     if (existing != g_diagnostics.end()) {
       return;
     }
@@ -87,7 +86,9 @@ namespace {
     return key == "layout" || key == "variant" || key == "options" || key == "numlock";
   }
 
-  [[nodiscard]] bool isKnownAuthKey(std::string_view key) { return key == "allow_empty_password"; }
+  [[nodiscard]] bool isKnownAuthKey(std::string_view key) {
+    return key == "allow_empty_password" || key == "autologin";
+  }
 
   [[nodiscard]] std::optional<std::string> stringValue(const toml::node& node) {
     if (const auto value = node.value<std::string>()) {
@@ -334,7 +335,11 @@ namespace {
             continue;
           }
           if (const auto value = entryNode.value<bool>()) {
-            config.authAllowEmptyPassword = *value;
+            if (entryView == "allow_empty_password") {
+              config.authAllowEmptyPassword = *value;
+            } else {
+              config.authAutoLogin = *value;
+            }
           }
         }
       }
@@ -551,6 +556,13 @@ namespace {
     if (config.authAllowEmptyPassword.has_value()) {
       toml::table auth;
       auth.insert_or_assign("allow_empty_password", *config.authAllowEmptyPassword);
+      if (config.authAutoLogin.has_value()) {
+        auth.insert_or_assign("autologin", *config.authAutoLogin);
+      }
+      root.insert("auth", std::move(auth));
+    } else if (config.authAutoLogin.has_value()) {
+      toml::table auth;
+      auth.insert_or_assign("autologin", *config.authAutoLogin);
       root.insert("auth", std::move(auth));
     }
 
@@ -797,7 +809,7 @@ namespace greeter::config {
     out << "# [appearance.wallpapers.<connector>] per-output wallpaper overrides\n";
     out << "# [output] name/layout/scale/scales/width/height/transforms, [idle] timeout, [cursor] theme/size/path\n";
     out << "# [keyboard] layout/variant/options/numlock\n";
-    out << "# [auth] allow_empty_password (bool, default false; enables fingerprint/smartcard PAM auth)\n";
+    out << "# [auth] allow_empty_password, autologin (bool; autologin requires [user].default)\n";
     out << '\n';
     out << formatToml(table);
 

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -70,6 +70,7 @@ namespace greeter::config {
     std::optional<bool> keyboardNumlock;
 
     std::optional<bool> authAllowEmptyPassword;
+    std::optional<bool> authAutoLogin;
   };
 
   // Sync + UI mutable file (sync.toml). Never managed by Nix. Loses to greeter.toml.

--- a/src/greeter/greeter_preferences.cpp
+++ b/src/greeter/greeter_preferences.cpp
@@ -448,6 +448,9 @@ namespace greeter {
     if (file.authAllowEmptyPassword.has_value()) {
       prefs.allowEmptyPassword = *file.authAllowEmptyPassword;
     }
+    if (file.authAutoLogin.has_value()) {
+      prefs.autoLogin = *file.authAutoLogin;
+    }
     return prefs;
   }
 

--- a/src/greeter/greeter_preferences.h
+++ b/src/greeter/greeter_preferences.h
@@ -31,6 +31,7 @@ namespace greeter {
     std::optional<float> scale;
     PasswordMaskStyle passwordMaskStyle = PasswordMaskStyle::Default;
     bool allowEmptyPassword = false;
+    bool autoLogin = false;
     bool hideLogo = false;
   };
 

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -6,8 +6,8 @@
 #include "core/log.h"
 #include "core/resource_paths.h"
 #include "greeter/appearance_config.h"
-#include "greeter/greeter_config_store.h"
 #include "greeter/appearance_sync.h"
+#include "greeter/greeter_config_store.h"
 #include "greeter/greeter_preferences.h"
 #include "greeter/greeter_sessions.h"
 #include "greeter/greeter_window.h"
@@ -599,6 +599,7 @@ void GreeterSurface::initialize(RenderContext* context) {
   applyScheme(m_selectedScheme);
   refreshSelectionLabels();
   applyInitialUserSelection();
+  tryAutoLogin();
 
   if (const auto& diagnostics = greeter::config::configDiagnostics(); !diagnostics.empty()) {
     const auto& diagnostic = diagnostics.front();
@@ -723,6 +724,8 @@ void GreeterSurface::reconcileKeyboardFocus() {
 void GreeterSurface::setWindow(GreeterWindow* window) { m_window = window; }
 
 void GreeterSurface::setGreetdClient(GreetdClient* client) { m_greetdClient = client; }
+
+void GreeterSurface::setAutoLoginAllowed(const bool allowed) noexcept { m_autoLoginAllowed = allowed; }
 
 void GreeterSurface::setUsername(const std::string& username) { m_username = username; }
 
@@ -1169,9 +1172,7 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
         }
     );
     m_configErrorHeading->setPosition(bannerX + padding, bannerY + padding);
-    m_configErrorLabel->setPosition(
-        bannerX + padding, bannerY + padding + m_configErrorHeading->height() + gap
-    );
+    m_configErrorLabel->setPosition(bannerX + padding, bannerY + padding + m_configErrorHeading->height() + gap);
   }
 
   syncHeaderUserAvatar(*renderer, headerGlyphSize, panelX, panelWidth, headerY);
@@ -1359,6 +1360,26 @@ void GreeterSurface::tryAuthenticate() {
   } else if (m_secretPromptWaiting) {
     postAuthResponse(m_password);
   }
+}
+
+void GreeterSurface::tryAutoLogin() {
+  if (!m_autoLogin || !m_autoLoginAllowed) {
+    return;
+  }
+  if (m_greetdClient == nullptr || !m_greetdClient->isConnected() || m_username.empty()) {
+    kLog.warn("autologin requires a connected greetd client and [user].default; showing the login screen");
+    return;
+  }
+
+  m_authenticating = true;
+  kLog.info("greetd: autologin create_session for '{}'", m_username);
+  if (!m_greetdClient->requestCreateSession(m_username)) {
+    onAuthError(m_greetdClient->lastError().value_or(GreetdError{GreetdErrorType::Error, "failed to send request"}));
+    return;
+  }
+  m_authSessionStarted = true;
+  m_pendingReplies.push_back(AuthRequest::CreateSession);
+  syncAuthInteractivity();
 }
 
 void GreeterSurface::onGreetdReadable() {
@@ -1908,6 +1929,12 @@ void GreeterSurface::syncWallpaperTexture() {
 void GreeterSurface::loadPreferences() {
   const auto prefs = greeter::loadGreeterPreferences();
   m_allowEmptyPassword = prefs.allowEmptyPassword;
+  // Autologin is deliberately tied to the declarative user setting. A CLI
+  // --user or a single discovered account must never enable it implicitly.
+  m_autoLogin = prefs.autoLogin && prefs.defaultUser.has_value() && !prefs.defaultUser->empty();
+  if (prefs.autoLogin && !m_autoLogin) {
+    kLog.warn("[auth].autologin requires an explicit [user].default; showing the login screen");
+  }
   const auto initialSession = greeter::resolveInitialSessionName(prefs);
 
   if (initialSession.has_value()) {

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -45,6 +45,8 @@ public:
   void setWindow(GreeterWindow* window);
   void setBoundOutputName(std::string outputName);
   void setGreetdClient(GreetdClient* client);
+  // Only one output view may own greetd's single authentication conversation.
+  void setAutoLoginAllowed(bool allowed) noexcept;
   void setUsername(const std::string& username);
   void setOnExitRequested(std::function<void()> callback);
   void setOnStateChanged(std::function<void(GreeterSurface*)> callback);
@@ -82,6 +84,7 @@ private:
   void syncScaledTypography();
   void layoutScene(std::uint32_t width, std::uint32_t height);
   void tryAuthenticate();
+  void tryAutoLogin();
   void handleGreetdResponse(const GreetdResponse& response);
   void handleAuthMessage(const GreetdAuthMessage& message);
   void postAuthResponse(const std::string& data);
@@ -206,6 +209,8 @@ private:
   bool m_canRebootToFirmware = false;
 
   bool m_allowEmptyPassword = false;
+  bool m_autoLogin = false;
+  bool m_autoLoginAllowed = true;
 
   // greetd replies in request order, so m_pendingReplies (a FIFO of these) tells
   // which request each reply answers.


### PR DESCRIPTION
## Summary

Add PAM autologin config

This is interesting for enabling seamless login from LUKS. This is better than skipping login altogether because this will also propagate to the keyring.

Happy to receive feedback and change the strategy here.

## Motivation

greetd’s `initial_session` bypasses PAM authentication, which prevents setups using a systemd initrd and `pam_systemd_loadkey` from unlocking a credential store during autologin.

This provides a greeter-side authenticated autologin path while retaining a safe interactive fallback.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

Ran it locally and verified that the LUKS password got propagated to login and that keyring did unlock without prompting for a password.

Config added:

```
[user]
default = USER

[auth]
autologin = true
```

## Manual Coverage

- [X] Tested under greetd (real login flow)
- [ ] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [X] Tested on NixOS (`programs.noctalia-greeter`)
- [ ] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `AGENTS.md` and `README.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation in [noctalia-docs](https://github.com/noctalia-dev/noctalia-docs) after merge, or this PR does not change user-facing configuration or behavior.
- [X] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes


