### PR TITLE
Add ability to show and hide buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Individual UI controls can be hidden under `[appearance]`; omitted options defau
 
 ```toml
 [appearance]
-hide_theme_selector = true
+hide_scheme_selector = true
 hide_shutdown_button = true
 hide_reboot_button = false
 hide_firmware_button = false

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ After installation:
 - [Set up optional Sync with Noctalia](docs/user/sync.md)
 - [Troubleshoot a login or display problem](docs/user/troubleshooting.md)
 
+### UI controls
+
+To hide the session picker, set `ui.show_session_selector = false` in `greeter.toml`.
+The selected session still follows CLI default, configured default, and the last
+session from `sync.toml`; if none is available, the first discovered session is used.
+
+Individual UI controls can be hidden under `[ui]`; omitted options default to `true`:
+
+```toml
+[ui]
+show_theme_selector = false
+show_shutdown_button = false
+show_reboot_button = true
+show_firmware_button = true
+```
+
 ## Scope
 
 Noctalia Greeter is a **display/login greeter** for greetd. It handles user/session selection and authentication UI.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ After installation:
 - [Set up optional Sync with Noctalia](docs/user/sync.md)
 - [Troubleshoot a login or display problem](docs/user/troubleshooting.md)
 
+### NixOS settings
+
+`settings` writes `/var/lib/noctalia-greeter/greeter.toml` (full declarative config,
+including appearance/palette when you set them). Sync + UI mutable data lives in
+`sync.toml` (not managed by Nix).
+Commented example: [`examples/greeter.toml`](examples/greeter.toml).
+
 ### UI controls
 
 To hide the session picker, set `appearance.hide_session_selector = true` in `greeter.toml`.

--- a/README.md
+++ b/README.md
@@ -50,18 +50,18 @@ After installation:
 
 ### UI controls
 
-To hide the session picker, set `ui.show_session_selector = false` in `greeter.toml`.
+To hide the session picker, set `appearance.hide_session_selector = true` in `greeter.toml`.
 The selected session still follows CLI default, configured default, and the last
 session from `sync.toml`; if none is available, the first discovered session is used.
 
-Individual UI controls can be hidden under `[ui]`; omitted options default to `true`:
+Individual UI controls can be hidden under `[appearance]`; omitted options default to `false`:
 
 ```toml
-[ui]
-show_theme_selector = false
-show_shutdown_button = false
-show_reboot_button = true
-show_firmware_button = true
+[appearance]
+hide_theme_selector = true
+hide_shutdown_button = true
+hide_reboot_button = false
+hide_firmware_button = false
 ```
 
 ## Scope

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -53,7 +53,7 @@ Set these keys in `greeter.toml`. A command-line `--session` or `--user` value t
 | `[appearance].password_style` | Password mask: `default` or `random` |
 | `[appearance].hide_logo` | Hide the Noctalia brand logo |
 | `[appearance].hide_session_selector` | Hide the session selector (`true` / `false`; default `false`) |
-| `[appearance].hide_theme_selector` | Hide the theme selector (`true` / `false`; default `false`) |
+| `[appearance].hide_scheme_selector` | Hide the scheme selector (`true` / `false`; default `false`) |
 | `[appearance].hide_shutdown_button` | Hide the shutdown button (`true` / `false`; default `false`) |
 | `[appearance].hide_reboot_button` | Hide the reboot button (`true` / `false`; default `false`) |
 | `[appearance].hide_firmware_button` | Hide the firmware button (`true` / `false`; default `false`) |

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -26,6 +26,8 @@ If `greeter.toml` is missing, the greeter uses built-in defaults. System setup c
 
 On NixOS, use `services.displayManager.noctalia-greeter.settings` with the nixpkgs module or `programs.noctalia-greeter.settings` with the project flake. Both materialize `greeter.toml` using a tmpfiles `L+` entry.
 
+The `[appearance].hide_*` keys are declarative `greeter.toml` settings. They are not read from or written to `sync.toml`.
+
 The **Synced** scheme uses a complete `[appearance.palette]` from `greeter.toml` when present, otherwise the same keys from `sync.toml`. Legacy live `appearance.json` is migrated into `sync.toml` once. See [Sync with Noctalia](sync.md) for the complete precedence and authorization model.
 
 ## Keys the greeter remembers
@@ -50,6 +52,11 @@ Set these keys in `greeter.toml`. A command-line `--session` or `--user` value t
 | `[appearance].scheme` | Color scheme: `Synced` or a built-in name such as `Noctalia` |
 | `[appearance].password_style` | Password mask: `default` or `random` |
 | `[appearance].hide_logo` | Hide the Noctalia brand logo |
+| `[appearance].hide_session_selector` | Hide the session selector (`true` / `false`; default `false`) |
+| `[appearance].hide_theme_selector` | Hide the theme selector (`true` / `false`; default `false`) |
+| `[appearance].hide_shutdown_button` | Hide the shutdown button (`true` / `false`; default `false`) |
+| `[appearance].hide_reboot_button` | Hide the reboot button (`true` / `false`; default `false`) |
+| `[appearance].hide_firmware_button` | Hide the firmware button (`true` / `false`; default `false`) |
 | `[appearance].power_buttons_position` | Power controls: `bottom-right` (default), `bottom-left`, `top-left`, `top-right`, or `hidden` |
 | `[appearance].scheme_selector_position` | Scheme picker: `top-right` (default), `top-left`, `bottom-left`, `bottom-right`, or `hidden` |
 | `[appearance].theme_mode` | Theme mode for the Synced appearance, such as `dark` |

--- a/examples/greeter.toml
+++ b/examples/greeter.toml
@@ -14,6 +14,18 @@
 [session]
 # Session Name from `noctalia-greeter sessions` (picker label, not .desktop id).
 default = "niri"
+# Set false to hide the session picker. The CLI default, this default, or the
+# last session from sync.toml is still used; if none is available, the first
+# discovered session is started.
+show_selector = true
+
+[ui]
+# All UI controls below are shown by default when omitted.
+show_session_selector = true
+show_theme_selector = true
+show_shutdown_button = true
+show_reboot_button = true
+show_firmware_button = true
 
 [user]
 # Opens the password step for this account on startup.

--- a/examples/greeter.toml
+++ b/examples/greeter.toml
@@ -28,7 +28,7 @@ password_style = "random"
 hide_logo = false
 # Hide individual controls. Omitted values default to false.
 hide_session_selector = false
-hide_theme_selector = false
+hide_scheme_selector = false
 hide_shutdown_button = false
 hide_reboot_button = false
 hide_firmware_button = false

--- a/examples/greeter.toml
+++ b/examples/greeter.toml
@@ -14,19 +14,6 @@
 [session]
 # Session Name from `noctalia-greeter sessions` (picker label, not .desktop id).
 default = "niri"
-# Set false to hide the session picker. The CLI default, this default, or the
-# last session from sync.toml is still used; if none is available, the first
-# discovered session is started.
-show_selector = true
-
-[ui]
-# All UI controls below are shown by default when omitted.
-show_session_selector = true
-show_theme_selector = true
-show_shutdown_button = true
-show_reboot_button = true
-show_firmware_button = true
-
 [user]
 # Opens the password step for this account on startup.
 default = "lysec"
@@ -39,6 +26,12 @@ scheme = "Synced"
 password_style = "random"
 # Hide the Noctalia brand logo on the login screen.
 hide_logo = false
+# Hide individual controls. Omitted values default to false.
+hide_session_selector = false
+hide_theme_selector = false
+hide_shutdown_button = false
+hide_reboot_button = false
+hide_firmware_button = false
 # Power controls: bottom-right (default), bottom-left, top-left, top-right, or hidden.
 power_buttons_position = "bottom-right"
 # Scheme picker: top-right (default), top-left, bottom-left, bottom-right, or hidden.

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -58,14 +58,14 @@ in
         Full declarative greeter.toml, symlinked into the Nix store and replaced on every
         activation. Configure everything here: session/user defaults, UI visibility, appearance (scheme,
         palette, wallpaper, font, ...), output, idle, cursor, keyboard, auth.
-        Sync/UI mutable data lives in sync.toml and is not managed by this option.
+         Sync/UI mutable data lives in sync.toml and is not managed by this option.
         Accepts a Nix attrset, raw TOML string, or path to a `.toml` file.
         See examples/greeter.toml in the noctalia-greeter repository.
       '';
       example = lib.literalExpression ''
         {
           session.default = "niri";
-          session.show_selector = false;
+          appearance.hide_session_selector = true;
           appearance = {
             scheme = "Synced";
             password_style = "default";

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -56,7 +56,7 @@ in
       default = { };
       description = ''
         Full declarative greeter.toml, symlinked into the Nix store and replaced on every
-        activation. Configure everything here: session/user defaults, appearance (scheme,
+        activation. Configure everything here: session/user defaults, UI visibility, appearance (scheme,
         palette, wallpaper, font, ...), output, idle, cursor, keyboard, auth.
         Sync/UI mutable data lives in sync.toml and is not managed by this option.
         Accepts a Nix attrset, raw TOML string, or path to a `.toml` file.
@@ -65,6 +65,7 @@ in
       example = lib.literalExpression ''
         {
           session.default = "niri";
+          session.show_selector = false;
           appearance = {
             scheme = "Synced";
             password_style = "default";

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -58,7 +58,7 @@ in
         Full declarative greeter.toml, symlinked into the Nix store and replaced on every
         activation. Configure everything here: session/user defaults, UI visibility, appearance (scheme,
         palette, wallpaper, font, ...), output, idle, cursor, keyboard, auth.
-         Sync/UI mutable data lives in sync.toml and is not managed by this option.
+        Sync/UI mutable data lives in sync.toml and is not managed by this option.
         Accepts a Nix attrset, raw TOML string, or path to a `.toml` file.
         See examples/greeter.toml in the noctalia-greeter repository.
       '';

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -45,7 +45,6 @@ namespace {
   [[nodiscard]] bool isKnownTopLevelKey(std::string_view key) {
     return key == "session"
         || key == "user"
-        || key == "ui"
         || key == "appearance"
         || key == "output"
         || key == "cursor"
@@ -57,23 +56,20 @@ namespace {
   [[nodiscard]] bool isKnownSessionKey(std::string_view key) {
     // "power"/"actions" are Sync-only (sync.toml); recognized here only so parseConfig
     // does not warn about them when parsing sync.toml through the shared session-table loop.
-    return key == "default" || key == "show_selector" || key == "last" || key == "power" || key == "actions";
+    return key == "default" || key == "last" || key == "power" || key == "actions";
   }
 
   [[nodiscard]] bool isKnownUserKey(std::string_view key) { return key == "default"; }
-
-  [[nodiscard]] bool isKnownUiKey(std::string_view key) {
-    return key == "show_session_selector"
-        || key == "show_theme_selector"
-        || key == "show_shutdown_button"
-        || key == "show_reboot_button"
-        || key == "show_firmware_button";
-  }
 
   [[nodiscard]] bool isKnownAppearanceKey(std::string_view key) {
     return key == "scheme"
         || key == "password_style"
         || key == "hide_logo"
+        || key == "hide_session_selector"
+        || key == "hide_theme_selector"
+        || key == "hide_shutdown_button"
+        || key == "hide_reboot_button"
+        || key == "hide_firmware_button"
         || key == "power_buttons_position"
         || key == "scheme_selector_position"
         || key == "theme_mode"
@@ -213,12 +209,6 @@ namespace {
           }
           if (entryView == "default") {
             config.sessionDefault = stringValue(entryNode);
-          } else if (entryView == "show_selector") {
-            if (const auto value = entryNode.value<bool>()) {
-              config.sessionShowSelector = *value;
-            } else {
-              kLog.warn("{}: invalid session.show_selector value", path.string());
-            }
           } else if (entryView == "last") {
             config.sessionLast = stringValue(entryNode);
           }
@@ -229,27 +219,6 @@ namespace {
             continue;
           }
           config.userDefault = stringValue(entryNode);
-        } else if (keyView == "ui") {
-          if (!isKnownUiKey(entryView)) {
-            warnUnknownSectionKey(path, keyView, entryView);
-            continue;
-          }
-          const auto value = entryNode.value<bool>();
-          if (!value.has_value()) {
-            kLog.warn("{}: invalid ui.{} value", path.string(), entryView);
-            continue;
-          }
-          if (entryView == "show_session_selector") {
-            config.uiShowSessionSelector = *value;
-          } else if (entryView == "show_theme_selector") {
-            config.uiShowThemeSelector = *value;
-          } else if (entryView == "show_shutdown_button") {
-            config.uiShowShutdownButton = *value;
-          } else if (entryView == "show_reboot_button") {
-            config.uiShowRebootButton = *value;
-          } else if (entryView == "show_firmware_button") {
-            config.uiShowFirmwareButton = *value;
-          }
         } else if (keyView == "appearance") {
           if (!isKnownAppearanceKey(entryView)) {
             warnUnknownSectionKey(path, keyView, entryView);
@@ -262,6 +231,26 @@ namespace {
           } else if (entryView == "hide_logo") {
             if (const auto value = entryNode.value<bool>()) {
               config.appearanceHideLogo = *value;
+            }
+          } else if (entryView == "hide_session_selector") {
+            if (const auto value = entryNode.value<bool>()) {
+              config.appearanceHideSessionSelector = *value;
+            }
+          } else if (entryView == "hide_theme_selector") {
+            if (const auto value = entryNode.value<bool>()) {
+              config.appearanceHideThemeSelector = *value;
+            }
+          } else if (entryView == "hide_shutdown_button") {
+            if (const auto value = entryNode.value<bool>()) {
+              config.appearanceHideShutdownButton = *value;
+            }
+          } else if (entryView == "hide_reboot_button") {
+            if (const auto value = entryNode.value<bool>()) {
+              config.appearanceHideRebootButton = *value;
+            }
+          } else if (entryView == "hide_firmware_button") {
+            if (const auto value = entryNode.value<bool>()) {
+              config.appearanceHideFirmwareButton = *value;
             }
           } else if (entryView == "power_buttons_position") {
             config.appearancePowerButtonsPosition = stringValue(entryNode);
@@ -494,9 +483,6 @@ namespace {
           table.insert_or_assign(std::string(key), value);
         }
     );
-    if (config.sessionShowSelector.has_value()) {
-      session.insert_or_assign("show_selector", *config.sessionShowSelector);
-    }
     if (!session.empty()) {
       root.insert("session", std::move(session));
     }
@@ -509,26 +495,6 @@ namespace {
     );
     if (!user.empty()) {
       root.insert("user", std::move(user));
-    }
-
-    toml::table ui;
-    if (config.uiShowThemeSelector.has_value()) {
-      ui.insert_or_assign("show_theme_selector", *config.uiShowThemeSelector);
-    }
-    if (config.uiShowSessionSelector.has_value()) {
-      ui.insert_or_assign("show_session_selector", *config.uiShowSessionSelector);
-    }
-    if (config.uiShowShutdownButton.has_value()) {
-      ui.insert_or_assign("show_shutdown_button", *config.uiShowShutdownButton);
-    }
-    if (config.uiShowRebootButton.has_value()) {
-      ui.insert_or_assign("show_reboot_button", *config.uiShowRebootButton);
-    }
-    if (config.uiShowFirmwareButton.has_value()) {
-      ui.insert_or_assign("show_firmware_button", *config.uiShowFirmwareButton);
-    }
-    if (!ui.empty()) {
-      root.insert("ui", std::move(ui));
     }
 
     toml::table appearance = buildAppearanceTomlTable(config.appearance);
@@ -546,6 +512,21 @@ namespace {
     );
     if (config.appearanceHideLogo.has_value()) {
       appearance.insert_or_assign("hide_logo", *config.appearanceHideLogo);
+    }
+    if (config.appearanceHideSessionSelector.has_value()) {
+      appearance.insert_or_assign("hide_session_selector", *config.appearanceHideSessionSelector);
+    }
+    if (config.appearanceHideThemeSelector.has_value()) {
+      appearance.insert_or_assign("hide_theme_selector", *config.appearanceHideThemeSelector);
+    }
+    if (config.appearanceHideShutdownButton.has_value()) {
+      appearance.insert_or_assign("hide_shutdown_button", *config.appearanceHideShutdownButton);
+    }
+    if (config.appearanceHideRebootButton.has_value()) {
+      appearance.insert_or_assign("hide_reboot_button", *config.appearanceHideRebootButton);
+    }
+    if (config.appearanceHideFirmwareButton.has_value()) {
+      appearance.insert_or_assign("hide_firmware_button", *config.appearanceHideFirmwareButton);
     }
     insertString(
         appearance, "power_buttons_position", config.appearancePowerButtonsPosition,
@@ -975,11 +956,10 @@ namespace greeter::config {
     out << "# Last-used session lives in sync.toml; UI/Sync also fall back to sync.toml for scheme\n";
     out << "# and output layout/transforms when not set here. Session power actions/menu entries are\n";
     out << "# Sync-only (sync.toml [session.power]/[[session.actions]]) and are not settable here.\n";
-    out << "# [session] default, show_selector, [user] default\n";
-    out << "# [ui] show_session_selector, show_theme_selector, show_shutdown_button, show_reboot_button, "
-           "show_firmware_button\n";
-    out << "# [appearance] scheme, password_style, hide_logo, power_buttons_position, scheme_selector_position, "
-           "theme_mode, corner_radius_scale, font_family\n";
+    out << "# [session] default, [user] default\n";
+    out << "# [appearance] scheme, password_style, hide_logo, hide_session_selector, hide_theme_selector, "
+           "hide_shutdown_button, hide_reboot_button, hide_firmware_button, power_buttons_position, "
+           "scheme_selector_position, theme_mode, corner_radius_scale, font_family\n";
     out << "# [appearance.palette] full color role table, [appearance.wallpaper] path/fill_mode/fill_color\n";
     out << "# [appearance.wallpapers.<connector>] per-output wallpaper overrides\n";
     out << "# [output] name/layout/scale/scales/width/height/transforms, [idle] timeout, [cursor] theme/size/path\n";

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -976,7 +976,8 @@ namespace greeter::config {
     out << "# and output layout/transforms when not set here. Session power actions/menu entries are\n";
     out << "# Sync-only (sync.toml [session.power]/[[session.actions]]) and are not settable here.\n";
     out << "# [session] default, show_selector, [user] default\n";
-    out << "# [ui] show_session_selector, show_theme_selector, show_shutdown_button, show_reboot_button, show_firmware_button\n";
+    out << "# [ui] show_session_selector, show_theme_selector, show_shutdown_button, show_reboot_button, "
+           "show_firmware_button\n";
     out << "# [appearance] scheme, password_style, hide_logo, power_buttons_position, scheme_selector_position, "
            "theme_mode, corner_radius_scale, font_family\n";
     out << "# [appearance.palette] full color role table, [appearance.wallpaper] path/fill_mode/fill_color\n";

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -45,6 +45,7 @@ namespace {
   [[nodiscard]] bool isKnownTopLevelKey(std::string_view key) {
     return key == "session"
         || key == "user"
+        || key == "ui"
         || key == "appearance"
         || key == "output"
         || key == "cursor"
@@ -56,10 +57,18 @@ namespace {
   [[nodiscard]] bool isKnownSessionKey(std::string_view key) {
     // "power"/"actions" are Sync-only (sync.toml); recognized here only so parseConfig
     // does not warn about them when parsing sync.toml through the shared session-table loop.
-    return key == "default" || key == "last" || key == "power" || key == "actions";
+    return key == "default" || key == "show_selector" || key == "last" || key == "power" || key == "actions";
   }
 
   [[nodiscard]] bool isKnownUserKey(std::string_view key) { return key == "default"; }
+
+  [[nodiscard]] bool isKnownUiKey(std::string_view key) {
+    return key == "show_session_selector"
+        || key == "show_theme_selector"
+        || key == "show_shutdown_button"
+        || key == "show_reboot_button"
+        || key == "show_firmware_button";
+  }
 
   [[nodiscard]] bool isKnownAppearanceKey(std::string_view key) {
     return key == "scheme"
@@ -204,6 +213,12 @@ namespace {
           }
           if (entryView == "default") {
             config.sessionDefault = stringValue(entryNode);
+          } else if (entryView == "show_selector") {
+            if (const auto value = entryNode.value<bool>()) {
+              config.sessionShowSelector = *value;
+            } else {
+              kLog.warn("{}: invalid session.show_selector value", path.string());
+            }
           } else if (entryView == "last") {
             config.sessionLast = stringValue(entryNode);
           }
@@ -214,6 +229,27 @@ namespace {
             continue;
           }
           config.userDefault = stringValue(entryNode);
+        } else if (keyView == "ui") {
+          if (!isKnownUiKey(entryView)) {
+            warnUnknownSectionKey(path, keyView, entryView);
+            continue;
+          }
+          const auto value = entryNode.value<bool>();
+          if (!value.has_value()) {
+            kLog.warn("{}: invalid ui.{} value", path.string(), entryView);
+            continue;
+          }
+          if (entryView == "show_session_selector") {
+            config.uiShowSessionSelector = *value;
+          } else if (entryView == "show_theme_selector") {
+            config.uiShowThemeSelector = *value;
+          } else if (entryView == "show_shutdown_button") {
+            config.uiShowShutdownButton = *value;
+          } else if (entryView == "show_reboot_button") {
+            config.uiShowRebootButton = *value;
+          } else if (entryView == "show_firmware_button") {
+            config.uiShowFirmwareButton = *value;
+          }
         } else if (keyView == "appearance") {
           if (!isKnownAppearanceKey(entryView)) {
             warnUnknownSectionKey(path, keyView, entryView);
@@ -458,6 +494,9 @@ namespace {
           table.insert_or_assign(std::string(key), value);
         }
     );
+    if (config.sessionShowSelector.has_value()) {
+      session.insert_or_assign("show_selector", *config.sessionShowSelector);
+    }
     if (!session.empty()) {
       root.insert("session", std::move(session));
     }
@@ -470,6 +509,26 @@ namespace {
     );
     if (!user.empty()) {
       root.insert("user", std::move(user));
+    }
+
+    toml::table ui;
+    if (config.uiShowThemeSelector.has_value()) {
+      ui.insert_or_assign("show_theme_selector", *config.uiShowThemeSelector);
+    }
+    if (config.uiShowSessionSelector.has_value()) {
+      ui.insert_or_assign("show_session_selector", *config.uiShowSessionSelector);
+    }
+    if (config.uiShowShutdownButton.has_value()) {
+      ui.insert_or_assign("show_shutdown_button", *config.uiShowShutdownButton);
+    }
+    if (config.uiShowRebootButton.has_value()) {
+      ui.insert_or_assign("show_reboot_button", *config.uiShowRebootButton);
+    }
+    if (config.uiShowFirmwareButton.has_value()) {
+      ui.insert_or_assign("show_firmware_button", *config.uiShowFirmwareButton);
+    }
+    if (!ui.empty()) {
+      root.insert("ui", std::move(ui));
     }
 
     toml::table appearance = buildAppearanceTomlTable(config.appearance);
@@ -916,7 +975,8 @@ namespace greeter::config {
     out << "# Last-used session lives in sync.toml; UI/Sync also fall back to sync.toml for scheme\n";
     out << "# and output layout/transforms when not set here. Session power actions/menu entries are\n";
     out << "# Sync-only (sync.toml [session.power]/[[session.actions]]) and are not settable here.\n";
-    out << "# [session] default, [user] default\n";
+    out << "# [session] default, show_selector, [user] default\n";
+    out << "# [ui] show_session_selector, show_theme_selector, show_shutdown_button, show_reboot_button, show_firmware_button\n";
     out << "# [appearance] scheme, password_style, hide_logo, power_buttons_position, scheme_selector_position, "
            "theme_mode, corner_radius_scale, font_family\n";
     out << "# [appearance.palette] full color role table, [appearance.wallpaper] path/fill_mode/fill_color\n";

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -66,7 +66,7 @@ namespace {
         || key == "password_style"
         || key == "hide_logo"
         || key == "hide_session_selector"
-        || key == "hide_theme_selector"
+        || key == "hide_scheme_selector"
         || key == "hide_shutdown_button"
         || key == "hide_reboot_button"
         || key == "hide_firmware_button"
@@ -236,9 +236,9 @@ namespace {
             if (const auto value = entryNode.value<bool>()) {
               config.appearanceHideSessionSelector = *value;
             }
-          } else if (entryView == "hide_theme_selector") {
+          } else if (entryView == "hide_scheme_selector") {
             if (const auto value = entryNode.value<bool>()) {
-              config.appearanceHideThemeSelector = *value;
+              config.appearanceHideSchemeSelector = *value;
             }
           } else if (entryView == "hide_shutdown_button") {
             if (const auto value = entryNode.value<bool>()) {
@@ -516,8 +516,8 @@ namespace {
     if (config.appearanceHideSessionSelector.has_value()) {
       appearance.insert_or_assign("hide_session_selector", *config.appearanceHideSessionSelector);
     }
-    if (config.appearanceHideThemeSelector.has_value()) {
-      appearance.insert_or_assign("hide_theme_selector", *config.appearanceHideThemeSelector);
+    if (config.appearanceHideSchemeSelector.has_value()) {
+      appearance.insert_or_assign("hide_scheme_selector", *config.appearanceHideSchemeSelector);
     }
     if (config.appearanceHideShutdownButton.has_value()) {
       appearance.insert_or_assign("hide_shutdown_button", *config.appearanceHideShutdownButton);
@@ -957,7 +957,7 @@ namespace greeter::config {
     out << "# and output layout/transforms when not set here. Session power actions/menu entries are\n";
     out << "# Sync-only (sync.toml [session.power]/[[session.actions]]) and are not settable here.\n";
     out << "# [session] default, [user] default\n";
-    out << "# [appearance] scheme, password_style, hide_logo, hide_session_selector, hide_theme_selector, "
+    out << "# [appearance] scheme, password_style, hide_logo, hide_session_selector, hide_scheme_selector, "
            "hide_shutdown_button, hide_reboot_button, hide_firmware_button, power_buttons_position, "
            "scheme_selector_position, theme_mode, corner_radius_scale, font_family\n";
     out << "# [appearance.palette] full color role table, [appearance.wallpaper] path/fill_mode/fill_color\n";

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -37,10 +37,17 @@ namespace greeter::config {
   // Full declarative greeter.toml. UI and Sync never write this file.
   struct GreeterConfigFile {
     std::optional<std::string> sessionDefault;
+    std::optional<bool> sessionShowSelector;
     // Legacy only: migrated into sync.toml; stripped on greeter.toml write.
     std::optional<std::string> sessionLast;
 
     std::optional<std::string> userDefault;
+
+    std::optional<bool> uiShowThemeSelector;
+    std::optional<bool> uiShowSessionSelector;
+    std::optional<bool> uiShowShutdownButton;
+    std::optional<bool> uiShowRebootButton;
+    std::optional<bool> uiShowFirmwareButton;
 
     // Declarative scheme (overrides sync.toml last scheme when set).
     std::optional<std::string> appearanceScheme;

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -37,22 +37,20 @@ namespace greeter::config {
   // Full declarative greeter.toml. UI and Sync never write this file.
   struct GreeterConfigFile {
     std::optional<std::string> sessionDefault;
-    std::optional<bool> sessionShowSelector;
     // Legacy only: migrated into sync.toml; stripped on greeter.toml write.
     std::optional<std::string> sessionLast;
 
     std::optional<std::string> userDefault;
 
-    std::optional<bool> uiShowThemeSelector;
-    std::optional<bool> uiShowSessionSelector;
-    std::optional<bool> uiShowShutdownButton;
-    std::optional<bool> uiShowRebootButton;
-    std::optional<bool> uiShowFirmwareButton;
-
     // Declarative scheme (overrides sync.toml last scheme when set).
     std::optional<std::string> appearanceScheme;
     std::optional<std::string> appearancePasswordStyle;
     std::optional<bool> appearanceHideLogo;
+    std::optional<bool> appearanceHideSessionSelector;
+    std::optional<bool> appearanceHideThemeSelector;
+    std::optional<bool> appearanceHideShutdownButton;
+    std::optional<bool> appearanceHideRebootButton;
+    std::optional<bool> appearanceHideFirmwareButton;
     // UI element positioning: "hidden", "bottom-left", "bottom-right", "top-left", "top-right"
     std::optional<std::string> appearancePowerButtonsPosition;
     std::optional<std::string> appearanceSchemeSelectorPosition;

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -47,7 +47,7 @@ namespace greeter::config {
     std::optional<std::string> appearancePasswordStyle;
     std::optional<bool> appearanceHideLogo;
     std::optional<bool> appearanceHideSessionSelector;
-    std::optional<bool> appearanceHideThemeSelector;
+    std::optional<bool> appearanceHideSchemeSelector;
     std::optional<bool> appearanceHideShutdownButton;
     std::optional<bool> appearanceHideRebootButton;
     std::optional<bool> appearanceHideFirmwareButton;

--- a/src/greeter/greeter_preferences.cpp
+++ b/src/greeter/greeter_preferences.cpp
@@ -437,24 +437,21 @@ namespace greeter {
 
     GreeterPreferences prefs;
     prefs.defaultSession = file.sessionDefault;
-    if (file.sessionShowSelector.has_value()) {
-      prefs.showSessionSelector = *file.sessionShowSelector;
-    }
     prefs.defaultUser = file.userDefault;
-    if (file.uiShowSessionSelector.has_value()) {
-      prefs.showSessionSelector = *file.uiShowSessionSelector;
+    if (file.appearanceHideSessionSelector.has_value()) {
+      prefs.hideSessionSelector = *file.appearanceHideSessionSelector;
     }
-    if (file.uiShowThemeSelector.has_value()) {
-      prefs.showThemeSelector = *file.uiShowThemeSelector;
+    if (file.appearanceHideThemeSelector.has_value()) {
+      prefs.hideThemeSelector = *file.appearanceHideThemeSelector;
     }
-    if (file.uiShowShutdownButton.has_value()) {
-      prefs.showShutdownButton = *file.uiShowShutdownButton;
+    if (file.appearanceHideShutdownButton.has_value()) {
+      prefs.hideShutdownButton = *file.appearanceHideShutdownButton;
     }
-    if (file.uiShowRebootButton.has_value()) {
-      prefs.showRebootButton = *file.uiShowRebootButton;
+    if (file.appearanceHideRebootButton.has_value()) {
+      prefs.hideRebootButton = *file.appearanceHideRebootButton;
     }
-    if (file.uiShowFirmwareButton.has_value()) {
-      prefs.showFirmwareButton = *file.uiShowFirmwareButton;
+    if (file.appearanceHideFirmwareButton.has_value()) {
+      prefs.hideFirmwareButton = *file.appearanceHideFirmwareButton;
     }
     prefs.session = sync.sessionLast;
     // greeter.toml is declarative and wins; sync.toml only carries the last UI pick.

--- a/src/greeter/greeter_preferences.cpp
+++ b/src/greeter/greeter_preferences.cpp
@@ -437,7 +437,25 @@ namespace greeter {
 
     GreeterPreferences prefs;
     prefs.defaultSession = file.sessionDefault;
+    if (file.sessionShowSelector.has_value()) {
+      prefs.showSessionSelector = *file.sessionShowSelector;
+    }
     prefs.defaultUser = file.userDefault;
+    if (file.uiShowSessionSelector.has_value()) {
+      prefs.showSessionSelector = *file.uiShowSessionSelector;
+    }
+    if (file.uiShowThemeSelector.has_value()) {
+      prefs.showThemeSelector = *file.uiShowThemeSelector;
+    }
+    if (file.uiShowShutdownButton.has_value()) {
+      prefs.showShutdownButton = *file.uiShowShutdownButton;
+    }
+    if (file.uiShowRebootButton.has_value()) {
+      prefs.showRebootButton = *file.uiShowRebootButton;
+    }
+    if (file.uiShowFirmwareButton.has_value()) {
+      prefs.showFirmwareButton = *file.uiShowFirmwareButton;
+    }
     prefs.session = sync.sessionLast;
     // greeter.toml is declarative and wins; sync.toml only carries the last UI pick.
     prefs.scheme = file.appearanceScheme.has_value() ? file.appearanceScheme : sync.appearanceScheme;

--- a/src/greeter/greeter_preferences.cpp
+++ b/src/greeter/greeter_preferences.cpp
@@ -441,8 +441,8 @@ namespace greeter {
     if (file.appearanceHideSessionSelector.has_value()) {
       prefs.hideSessionSelector = *file.appearanceHideSessionSelector;
     }
-    if (file.appearanceHideThemeSelector.has_value()) {
-      prefs.hideThemeSelector = *file.appearanceHideThemeSelector;
+    if (file.appearanceHideSchemeSelector.has_value()) {
+      prefs.hideSchemeSelector = *file.appearanceHideSchemeSelector;
     }
     if (file.appearanceHideShutdownButton.has_value()) {
       prefs.hideShutdownButton = *file.appearanceHideShutdownButton;

--- a/src/greeter/greeter_preferences.h
+++ b/src/greeter/greeter_preferences.h
@@ -23,7 +23,12 @@ namespace greeter {
 
   struct GreeterPreferences {
     std::optional<std::string> defaultSession;
+    bool showSessionSelector = true;
     std::optional<std::string> defaultUser;
+    bool showThemeSelector = true;
+    bool showShutdownButton = true;
+    bool showRebootButton = true;
+    bool showFirmwareButton = true;
     std::optional<std::string> session;
     std::optional<std::string> scheme;
     std::optional<std::string> output;

--- a/src/greeter/greeter_preferences.h
+++ b/src/greeter/greeter_preferences.h
@@ -23,12 +23,12 @@ namespace greeter {
 
   struct GreeterPreferences {
     std::optional<std::string> defaultSession;
-    bool showSessionSelector = true;
+    bool hideSessionSelector = false;
     std::optional<std::string> defaultUser;
-    bool showThemeSelector = true;
-    bool showShutdownButton = true;
-    bool showRebootButton = true;
-    bool showFirmwareButton = true;
+    bool hideThemeSelector = false;
+    bool hideShutdownButton = false;
+    bool hideRebootButton = false;
+    bool hideFirmwareButton = false;
     std::optional<std::string> session;
     std::optional<std::string> scheme;
     std::optional<std::string> output;

--- a/src/greeter/greeter_preferences.h
+++ b/src/greeter/greeter_preferences.h
@@ -25,7 +25,7 @@ namespace greeter {
     std::optional<std::string> defaultSession;
     bool hideSessionSelector = false;
     std::optional<std::string> defaultUser;
-    bool hideThemeSelector = false;
+    bool hideSchemeSelector = false;
     bool hideShutdownButton = false;
     bool hideRebootButton = false;
     bool hideFirmwareButton = false;

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -685,7 +685,9 @@ bool GreeterSurface::showsUserDropdown() const noexcept { return m_users.size() 
 
 bool GreeterSurface::showsSessionSelector() const noexcept { return !m_hideSessionSelector; }
 
-bool GreeterSurface::showsThemeSelector() const noexcept { return !m_hideThemeSelector; }
+bool GreeterSurface::showsSchemeSelector() const noexcept {
+  return !m_hideSchemeSelector && m_schemeSelectorPosition != "hidden";
+}
 
 bool GreeterSurface::showsShutdownButton() const { return !m_hideShutdownButton && power::hasSyncedAction("shutdown"); }
 
@@ -1227,7 +1229,7 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
   const float inputWidth = std::max(120.0f, contentWidth - buttonWidth - gap);
 
   const float selectorH = Style::controlHeightSm();
-  if (showsThemeSelector() && m_schemeSelectorPosition != "hidden") {
+  if (showsSchemeSelector()) {
     const float schemeW = measureIconSelectorWidth(m_schemeSelectIcon, m_schemeSelectGlyph);
     float schemeX;
     float schemeY;
@@ -2017,7 +2019,7 @@ void GreeterSurface::loadPreferences() {
   const auto prefs = greeter::loadGreeterPreferences();
   m_allowEmptyPassword = prefs.allowEmptyPassword;
   m_hideSessionSelector = prefs.hideSessionSelector;
-  m_hideThemeSelector = prefs.hideThemeSelector;
+  m_hideSchemeSelector = prefs.hideSchemeSelector;
   m_hideShutdownButton = prefs.hideShutdownButton;
   m_hideRebootButton = prefs.hideRebootButton;
   m_hideFirmwareButton = prefs.hideFirmwareButton;
@@ -2103,7 +2105,7 @@ void GreeterSurface::toggleSessionMenu() {
 }
 
 void GreeterSurface::toggleSchemeMenu() {
-  if (!showsThemeSelector() || m_schemeSelectorPosition == "hidden") {
+  if (!showsSchemeSelector()) {
     return;
   }
   m_schemeMenuOpen = !m_schemeMenuOpen;
@@ -2214,20 +2216,24 @@ void GreeterSurface::rebuildFocusRing() {
   if (showsSessionSelector() && m_sessionSelectArea != nullptr) {
     m_focusRing.push_back({m_sessionSelectArea, [this]() { toggleSessionMenu(); }});
   }
-  if (showsThemeSelector() && m_schemeSelectArea != nullptr) {
+  if (showsSchemeSelector() && m_schemeSelectArea != nullptr) {
     m_focusRing.push_back({m_schemeSelectArea, [this]() { toggleSchemeMenu(); }});
   }
 
-  if (showsFirmwareButton() && m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr
+  if (showsFirmwareButton()
+      && m_firmwareButton != nullptr
+      && m_firmwareButton->inputArea() != nullptr
       && m_firmwareButton->visible()) {
     m_focusRing.push_back({m_firmwareButton->inputArea(), []() { power::rebootToFirmwareSetup(); }});
   }
-  if (showsRebootButton() && m_rebootButton != nullptr
+  if (showsRebootButton()
+      && m_rebootButton != nullptr
       && m_rebootButton->inputArea() != nullptr
       && m_rebootButton->visible()) {
     m_focusRing.push_back({m_rebootButton->inputArea(), []() { power::reboot(); }});
   }
-  if (showsShutdownButton() && m_shutdownButton != nullptr
+  if (showsShutdownButton()
+      && m_shutdownButton != nullptr
       && m_shutdownButton->inputArea() != nullptr
       && m_shutdownButton->visible()) {
     m_focusRing.push_back({m_shutdownButton->inputArea(), []() { power::powerOff(); }});
@@ -2911,7 +2917,7 @@ bool GreeterSurface::handleNavigationKey(std::uint32_t sym, std::uint32_t utf32,
     return true;
   }
   if (KeySymbol::isF7(sym)) {
-    if (!showsThemeSelector() || m_schemeSelectorPosition == "hidden") {
+    if (!showsSchemeSelector()) {
       return true;
     }
     if (m_schemeMenuOpen) {
@@ -3476,7 +3482,7 @@ void GreeterSurface::rebuildSessionMenu() {
 
 void GreeterSurface::rebuildSchemeMenu() {
   clearSchemeMenu();
-  if (!showsThemeSelector() || !m_schemeMenuOpen || m_schemeNames.empty()) {
+  if (!showsSchemeSelector() || !m_schemeMenuOpen || m_schemeNames.empty()) {
     return;
   }
   // Open upward when selector is at the bottom, downward otherwise

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -683,6 +683,10 @@ void GreeterSurface::applyInitialUserSelection() {
 
 bool GreeterSurface::showsUserDropdown() const noexcept { return m_users.size() > 1; }
 
+bool GreeterSurface::showsSessionSelector() const noexcept { return m_showSessionSelector; }
+
+bool GreeterSurface::showsThemeSelector() const noexcept { return m_showThemeSelector; }
+
 void GreeterSurface::setKeyboardOwner(const bool owner) noexcept {
   m_isKeyboardOwner = owner;
   if (owner) {
@@ -1103,11 +1107,12 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
   const float headerBlockHeight = headerTopPadding + headerGlyphBlock + subtitleGap + headerToContentGap;
 
   const float sessionRowH = rowHeight;
-  const float sessionRowGap = rowGap;
+  const float sessionRowGap = showsSessionSelector() ? rowGap : 0.0f;
 
   const float userBlockHeight = showsUserDropdown() ? rowHeight : 0.0f;
-  const float userPickerContentHeight = userBlockHeight + sessionRowGap + sessionRowH;
-  const float passwordContentHeight = Style::controlHeight() + sessionRowGap + sessionRowH;
+  const float userPickerContentHeight = userBlockHeight + (showsSessionSelector() ? sessionRowGap + sessionRowH : 0.0f);
+  const float passwordContentHeight =
+      Style::controlHeight() + (showsSessionSelector() ? sessionRowGap + sessionRowH : 0.0f);
   const float contentBlockHeight = m_passwordVisible ? passwordContentHeight : userPickerContentHeight;
 
   const bool hasStatus = !m_status.empty();
@@ -1216,19 +1221,11 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
   const float inputWidth = std::max(120.0f, contentWidth - buttonWidth - gap);
 
   const float selectorH = Style::controlHeightSm();
-  const float schemeW = measureIconSelectorWidth(m_schemeSelectIcon, m_schemeSelectGlyph);
-
-  // Determine scheme selector position based on config
-  float schemeX;
-  float schemeY;
-  if (m_schemeSelectorPosition == "hidden") {
-    // Hide all selector parts (always non-null after initialize())
-    m_schemeSelectBox->setVisible(false);
-    m_schemeSelectIcon->setVisible(false);
-    m_schemeSelectGlyph->setVisible(false);
-    m_schemeSelectArea->setVisible(false);
-    m_schemeSelectLabel->setVisible(false);
-  } else {
+  if (showsThemeSelector() && m_schemeSelectorPosition != "hidden") {
+    const float schemeW = measureIconSelectorWidth(m_schemeSelectIcon, m_schemeSelectGlyph);
+    float schemeX;
+    float schemeY;
+    // Determine scheme selector position based on config.
     if (m_schemeSelectorPosition == "top-left") {
       schemeX = ox + Style::spaceLg();
       schemeY = oy + Style::spaceLg();
@@ -1239,7 +1236,7 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
       schemeX = ox + sw - schemeW - Style::spaceLg();
       schemeY = oy + sh - selectorH - Style::spaceLg();
     } else {
-      // Default: top-right
+      // Default: top-right.
       schemeX = ox + sw - schemeW - Style::spaceLg();
       schemeY = oy + Style::spaceLg();
     }
@@ -1247,6 +1244,12 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
         m_schemeSelectBox, m_schemeSelectIcon, m_schemeSelectGlyph, m_schemeSelectArea, schemeX, schemeY, schemeW,
         selectorH
     );
+  } else {
+    m_schemeSelectBox->setVisible(false);
+    m_schemeSelectIcon->setVisible(false);
+    m_schemeSelectGlyph->setVisible(false);
+    m_schemeSelectArea->setVisible(false);
+    m_schemeSelectLabel->setVisible(false);
   }
   if (m_schemeSelectLabel != nullptr) {
     m_schemeSelectLabel->setVisible(false);
@@ -1314,9 +1317,17 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
     m_backButton->setVisible(false);
   }
 
-  const float sessionY = m_passwordVisible ? (contentTop + Style::controlHeight() + sessionRowGap)
-                                           : (contentTop + userBlockHeight + sessionRowGap);
-  layoutPanelSessionSelector(contentLeft, sessionY, contentWidth, sessionRowH);
+  if (showsSessionSelector()) {
+    const float sessionY = m_passwordVisible ? (contentTop + Style::controlHeight() + sessionRowGap)
+                                             : (contentTop + userBlockHeight + sessionRowGap);
+    layoutPanelSessionSelector(contentLeft, sessionY, contentWidth, sessionRowH);
+  } else {
+    m_sessionSelectBox->setVisible(false);
+    m_sessionSelectIcon->setVisible(false);
+    m_sessionSelectLabel->setVisible(false);
+    m_sessionSelectGlyph->setVisible(false);
+    m_sessionSelectArea->setVisible(false);
+  }
 
   if (hasStatus) {
     const float statusY = contentTop + contentBlockHeight + statusGap;
@@ -1999,6 +2010,11 @@ void GreeterSurface::syncWallpaperTexture() {
 void GreeterSurface::loadPreferences() {
   const auto prefs = greeter::loadGreeterPreferences();
   m_allowEmptyPassword = prefs.allowEmptyPassword;
+  m_showSessionSelector = prefs.showSessionSelector;
+  m_showThemeSelector = prefs.showThemeSelector;
+  m_showShutdownButton = prefs.showShutdownButton;
+  m_showRebootButton = prefs.showRebootButton;
+  m_showFirmwareButton = prefs.showFirmwareButton;
   const auto initialSession = greeter::resolveInitialSessionName(prefs);
 
   if (initialSession.has_value()) {
@@ -2066,6 +2082,9 @@ void GreeterSurface::openUserMenu() {
 }
 
 void GreeterSurface::toggleSessionMenu() {
+  if (!showsSessionSelector()) {
+    return;
+  }
   m_sessionMenuOpen = !m_sessionMenuOpen;
   if (m_sessionMenuOpen) {
     m_userMenuOpen = false;
@@ -2078,10 +2097,7 @@ void GreeterSurface::toggleSessionMenu() {
 }
 
 void GreeterSurface::toggleSchemeMenu() {
-  // Don't toggle the menu if the selector is hidden
-  if (m_schemeSelectorPosition == "hidden" && m_schemeMenuOpen) {
-    m_schemeMenuOpen = false;
-    requestLayout();
+  if (!showsThemeSelector() || m_schemeSelectorPosition == "hidden") {
     return;
   }
   m_schemeMenuOpen = !m_schemeMenuOpen;
@@ -2189,20 +2205,23 @@ void GreeterSurface::rebuildFocusRing() {
                            }});
   }
 
-  if (m_sessionSelectArea != nullptr) {
+  if (showsSessionSelector() && m_sessionSelectArea != nullptr) {
     m_focusRing.push_back({m_sessionSelectArea, [this]() { toggleSessionMenu(); }});
   }
-  if (m_schemeSelectArea != nullptr && m_schemeSelectArea->visible()) {
+  if (showsThemeSelector() && m_schemeSelectArea != nullptr) {
     m_focusRing.push_back({m_schemeSelectArea, [this]() { toggleSchemeMenu(); }});
   }
 
-  if (m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr && m_firmwareButton->visible()) {
+  if (m_showFirmwareButton && m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr
+      && m_firmwareButton->visible()) {
     m_focusRing.push_back({m_firmwareButton->inputArea(), []() { power::rebootToFirmwareSetup(); }});
   }
-  if (m_rebootButton != nullptr && m_rebootButton->inputArea() != nullptr && m_rebootButton->visible()) {
+  if (m_showRebootButton && power::hasSyncedAction("reboot") && m_rebootButton != nullptr
+      && m_rebootButton->inputArea() != nullptr && m_rebootButton->visible()) {
     m_focusRing.push_back({m_rebootButton->inputArea(), []() { power::reboot(); }});
   }
-  if (m_shutdownButton != nullptr && m_shutdownButton->inputArea() != nullptr && m_shutdownButton->visible()) {
+  if (m_showShutdownButton && power::hasSyncedAction("shutdown") && m_shutdownButton != nullptr
+      && m_shutdownButton->inputArea() != nullptr && m_shutdownButton->visible()) {
     m_focusRing.push_back({m_shutdownButton->inputArea(), []() { power::powerOff(); }});
   }
 
@@ -2543,9 +2562,13 @@ void GreeterSurface::layoutPowerButtons(float ox, float oy, float sw, float sh) 
     y = oy + sh - size - margin;
   }
 
-  const auto place = [&](Button* btn, float x) {
+  const auto place = [&](Button* btn, float x, bool allowed) {
     if (btn == nullptr) {
-      return;
+      return false;
+    }
+    if (!allowed) {
+      btn->setVisible(false);
+      return false;
     }
     btn->setVisible(true);
     btn->setRadius(Style::scaledRadius(Style::controlHeightBase * 0.5f));
@@ -2563,29 +2586,30 @@ void GreeterSurface::layoutPowerButtons(float ox, float oy, float sw, float sh) 
       );
       glyph->setSize(std::max(glyphW, 1.0f), std::max(glyphH, 1.0f));
     }
+    return true;
   };
 
-  // Determine horizontal placement: right-aligned (default) or left-aligned
+  // Determine horizontal placement: right-aligned (default) or left-aligned.
   if (m_powerButtonsPosition == "bottom-left" || m_powerButtonsPosition == "top-left") {
-    // Left-aligned: firmware → reboot → shutdown (left to right)
+    // Left-aligned: firmware, reboot, shutdown (left to right).
     float x = ox + margin;
-    if (m_firmwareButton != nullptr) {
-      place(m_firmwareButton, x);
+    if (place(m_firmwareButton, x, m_showFirmwareButton)) {
       x += size + gap;
     }
-    place(m_rebootButton, x);
-    x += size + gap;
-    place(m_shutdownButton, x);
-  } else {
-    // Right-aligned (default): shutdown → reboot → firmware (right to left)
-    float x = ox + sw - size - margin;
-    place(m_shutdownButton, x);
-    x -= size + gap;
-    place(m_rebootButton, x);
-    if (m_firmwareButton != nullptr) {
-      x -= size + gap;
-      place(m_firmwareButton, x);
+    if (place(m_rebootButton, x, m_showRebootButton && power::hasSyncedAction("reboot"))) {
+      x += size + gap;
     }
+    (void)place(m_shutdownButton, x, m_showShutdownButton && power::hasSyncedAction("shutdown"));
+  } else {
+    // Right-aligned (default): shutdown, reboot, firmware (right to left).
+    float x = ox + sw - size - margin;
+    if (place(m_shutdownButton, x, m_showShutdownButton && power::hasSyncedAction("shutdown"))) {
+      x -= size + gap;
+    }
+    if (place(m_rebootButton, x, m_showRebootButton && power::hasSyncedAction("reboot"))) {
+      x -= size + gap;
+    }
+    (void)place(m_firmwareButton, x, m_showFirmwareButton);
   }
 }
 
@@ -2865,6 +2889,9 @@ bool GreeterSurface::handleNavigationKey(std::uint32_t sym, std::uint32_t utf32,
   // F3 / F7 jump straight to the session / color-scheme menus from anywhere
   // (even from inside the password field or with another menu open).
   if (KeySymbol::isF3(sym)) {
+    if (!showsSessionSelector()) {
+      return true;
+    }
     if (m_sessionMenuOpen) {
       closeMenusAndRestoreFocus();
     } else {
@@ -2876,8 +2903,7 @@ bool GreeterSurface::handleNavigationKey(std::uint32_t sym, std::uint32_t utf32,
     return true;
   }
   if (KeySymbol::isF7(sym)) {
-    // Don't respond if the scheme selector is hidden
-    if (m_schemeSelectorPosition == "hidden") {
+    if (!showsThemeSelector() || m_schemeSelectorPosition == "hidden") {
       return true;
     }
     if (m_schemeMenuOpen) {
@@ -3425,7 +3451,7 @@ void GreeterSurface::buildMenu(
 
 void GreeterSurface::rebuildSessionMenu() {
   clearSessionMenu();
-  if (!m_sessionMenuOpen || m_sessions.empty()) {
+  if (!showsSessionSelector() || !m_sessionMenuOpen || m_sessions.empty()) {
     return;
   }
   std::vector<std::string> names;
@@ -3442,7 +3468,7 @@ void GreeterSurface::rebuildSessionMenu() {
 
 void GreeterSurface::rebuildSchemeMenu() {
   clearSchemeMenu();
-  if (!m_schemeMenuOpen || m_schemeNames.empty()) {
+  if (!showsThemeSelector() || !m_schemeMenuOpen || m_schemeNames.empty()) {
     return;
   }
   // Open upward when selector is at the bottom, downward otherwise

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -2216,12 +2216,18 @@ void GreeterSurface::rebuildFocusRing() {
       && m_firmwareButton->visible()) {
     m_focusRing.push_back({m_firmwareButton->inputArea(), []() { power::rebootToFirmwareSetup(); }});
   }
-  if (m_showRebootButton && power::hasSyncedAction("reboot") && m_rebootButton != nullptr
-      && m_rebootButton->inputArea() != nullptr && m_rebootButton->visible()) {
+  if (m_showRebootButton
+      && power::hasSyncedAction("reboot")
+      && m_rebootButton != nullptr
+      && m_rebootButton->inputArea() != nullptr
+      && m_rebootButton->visible()) {
     m_focusRing.push_back({m_rebootButton->inputArea(), []() { power::reboot(); }});
   }
-  if (m_showShutdownButton && power::hasSyncedAction("shutdown") && m_shutdownButton != nullptr
-      && m_shutdownButton->inputArea() != nullptr && m_shutdownButton->visible()) {
+  if (m_showShutdownButton
+      && power::hasSyncedAction("shutdown")
+      && m_shutdownButton != nullptr
+      && m_shutdownButton->inputArea() != nullptr
+      && m_shutdownButton->visible()) {
     m_focusRing.push_back({m_shutdownButton->inputArea(), []() { power::powerOff(); }});
   }
 

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -683,9 +683,15 @@ void GreeterSurface::applyInitialUserSelection() {
 
 bool GreeterSurface::showsUserDropdown() const noexcept { return m_users.size() > 1; }
 
-bool GreeterSurface::showsSessionSelector() const noexcept { return m_showSessionSelector; }
+bool GreeterSurface::showsSessionSelector() const noexcept { return !m_hideSessionSelector; }
 
-bool GreeterSurface::showsThemeSelector() const noexcept { return m_showThemeSelector; }
+bool GreeterSurface::showsThemeSelector() const noexcept { return !m_hideThemeSelector; }
+
+bool GreeterSurface::showsShutdownButton() const { return !m_hideShutdownButton && power::hasSyncedAction("shutdown"); }
+
+bool GreeterSurface::showsRebootButton() const { return !m_hideRebootButton && power::hasSyncedAction("reboot"); }
+
+bool GreeterSurface::showsFirmwareButton() const noexcept { return !m_hideFirmwareButton; }
 
 void GreeterSurface::setKeyboardOwner(const bool owner) noexcept {
   m_isKeyboardOwner = owner;
@@ -2010,11 +2016,11 @@ void GreeterSurface::syncWallpaperTexture() {
 void GreeterSurface::loadPreferences() {
   const auto prefs = greeter::loadGreeterPreferences();
   m_allowEmptyPassword = prefs.allowEmptyPassword;
-  m_showSessionSelector = prefs.showSessionSelector;
-  m_showThemeSelector = prefs.showThemeSelector;
-  m_showShutdownButton = prefs.showShutdownButton;
-  m_showRebootButton = prefs.showRebootButton;
-  m_showFirmwareButton = prefs.showFirmwareButton;
+  m_hideSessionSelector = prefs.hideSessionSelector;
+  m_hideThemeSelector = prefs.hideThemeSelector;
+  m_hideShutdownButton = prefs.hideShutdownButton;
+  m_hideRebootButton = prefs.hideRebootButton;
+  m_hideFirmwareButton = prefs.hideFirmwareButton;
   const auto initialSession = greeter::resolveInitialSessionName(prefs);
 
   if (initialSession.has_value()) {
@@ -2212,20 +2218,16 @@ void GreeterSurface::rebuildFocusRing() {
     m_focusRing.push_back({m_schemeSelectArea, [this]() { toggleSchemeMenu(); }});
   }
 
-  if (m_showFirmwareButton && m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr
+  if (showsFirmwareButton() && m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr
       && m_firmwareButton->visible()) {
     m_focusRing.push_back({m_firmwareButton->inputArea(), []() { power::rebootToFirmwareSetup(); }});
   }
-  if (m_showRebootButton
-      && power::hasSyncedAction("reboot")
-      && m_rebootButton != nullptr
+  if (showsRebootButton() && m_rebootButton != nullptr
       && m_rebootButton->inputArea() != nullptr
       && m_rebootButton->visible()) {
     m_focusRing.push_back({m_rebootButton->inputArea(), []() { power::reboot(); }});
   }
-  if (m_showShutdownButton
-      && power::hasSyncedAction("shutdown")
-      && m_shutdownButton != nullptr
+  if (showsShutdownButton() && m_shutdownButton != nullptr
       && m_shutdownButton->inputArea() != nullptr
       && m_shutdownButton->visible()) {
     m_focusRing.push_back({m_shutdownButton->inputArea(), []() { power::powerOff(); }});
@@ -2599,23 +2601,23 @@ void GreeterSurface::layoutPowerButtons(float ox, float oy, float sw, float sh) 
   if (m_powerButtonsPosition == "bottom-left" || m_powerButtonsPosition == "top-left") {
     // Left-aligned: firmware, reboot, shutdown (left to right).
     float x = ox + margin;
-    if (place(m_firmwareButton, x, m_showFirmwareButton)) {
+    if (place(m_firmwareButton, x, showsFirmwareButton())) {
       x += size + gap;
     }
-    if (place(m_rebootButton, x, m_showRebootButton && power::hasSyncedAction("reboot"))) {
+    if (place(m_rebootButton, x, showsRebootButton())) {
       x += size + gap;
     }
-    (void)place(m_shutdownButton, x, m_showShutdownButton && power::hasSyncedAction("shutdown"));
+    (void)place(m_shutdownButton, x, showsShutdownButton());
   } else {
     // Right-aligned (default): shutdown, reboot, firmware (right to left).
     float x = ox + sw - size - margin;
-    if (place(m_shutdownButton, x, m_showShutdownButton && power::hasSyncedAction("shutdown"))) {
+    if (place(m_shutdownButton, x, showsShutdownButton())) {
       x -= size + gap;
     }
-    if (place(m_rebootButton, x, m_showRebootButton && power::hasSyncedAction("reboot"))) {
+    if (place(m_rebootButton, x, showsRebootButton())) {
       x -= size + gap;
     }
-    (void)place(m_firmwareButton, x, m_showFirmwareButton);
+    (void)place(m_firmwareButton, x, showsFirmwareButton());
   }
 }
 

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -156,6 +156,9 @@ private:
   [[nodiscard]] bool showsUserDropdown() const noexcept;
   [[nodiscard]] bool showsSessionSelector() const noexcept;
   [[nodiscard]] bool showsThemeSelector() const noexcept;
+  [[nodiscard]] bool showsShutdownButton() const;
+  [[nodiscard]] bool showsRebootButton() const;
+  [[nodiscard]] bool showsFirmwareButton() const noexcept;
   void savePreferences() const;
   void buildSchemeNames();
   void applyScheme(std::size_t schemeIndex);
@@ -220,11 +223,11 @@ private:
   bool m_canRebootToFirmware = false;
 
   bool m_allowEmptyPassword = false;
-  bool m_showSessionSelector = true;
-  bool m_showThemeSelector = true;
-  bool m_showShutdownButton = true;
-  bool m_showRebootButton = true;
-  bool m_showFirmwareButton = true;
+  bool m_hideSessionSelector = false;
+  bool m_hideThemeSelector = false;
+  bool m_hideShutdownButton = false;
+  bool m_hideRebootButton = false;
+  bool m_hideFirmwareButton = false;
 
   // greetd replies in request order, so m_pendingReplies (a FIFO of these) tells
   // which request each reply answers.

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -154,6 +154,8 @@ private:
   void reconcileKeyboardFocus();
   [[nodiscard]] bool ownsInputArea(const InputArea* area) const;
   [[nodiscard]] bool showsUserDropdown() const noexcept;
+  [[nodiscard]] bool showsSessionSelector() const noexcept;
+  [[nodiscard]] bool showsThemeSelector() const noexcept;
   void savePreferences() const;
   void buildSchemeNames();
   void applyScheme(std::size_t schemeIndex);
@@ -218,6 +220,11 @@ private:
   bool m_canRebootToFirmware = false;
 
   bool m_allowEmptyPassword = false;
+  bool m_showSessionSelector = true;
+  bool m_showThemeSelector = true;
+  bool m_showShutdownButton = true;
+  bool m_showRebootButton = true;
+  bool m_showFirmwareButton = true;
 
   // greetd replies in request order, so m_pendingReplies (a FIFO of these) tells
   // which request each reply answers.

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -155,7 +155,7 @@ private:
   [[nodiscard]] bool ownsInputArea(const InputArea* area) const;
   [[nodiscard]] bool showsUserDropdown() const noexcept;
   [[nodiscard]] bool showsSessionSelector() const noexcept;
-  [[nodiscard]] bool showsThemeSelector() const noexcept;
+  [[nodiscard]] bool showsSchemeSelector() const noexcept;
   [[nodiscard]] bool showsShutdownButton() const;
   [[nodiscard]] bool showsRebootButton() const;
   [[nodiscard]] bool showsFirmwareButton() const noexcept;
@@ -224,7 +224,7 @@ private:
 
   bool m_allowEmptyPassword = false;
   bool m_hideSessionSelector = false;
-  bool m_hideThemeSelector = false;
+  bool m_hideSchemeSelector = false;
   bool m_hideShutdownButton = false;
   bool m_hideRebootButton = false;
   bool m_hideFirmwareButton = false;


### PR DESCRIPTION
## Summary

Added configurable visibility for the session selector, theme selector, and individual power buttons. 
## Motivation

Allows users to simplify the greeter UI and hide controls they do not need, while preserving existing defaults and session selection priority.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None.

## Testing

- `meson compile -C build`
- `git diff --check`
- `meson test -C build` reports that no tests are defined.
- Manual greetd login testing was performed.

## Manual Coverage

- [x] Tested under greetd (real login flow)
- [x] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [x] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [ ] Tested on NixOS (`programs.noctalia-greeter`)
- [ ] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Screenshots / Videos
<img width="1440" height="1752" alt="2026-08-22-233202_hyprshot" src="https://github.com/user-attachments/assets/74e987a9-fc9a-4713-b86c-e34c2e1eb6ac" />


## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `AGENTS.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation in [noctalia-docs](https://github.com/noctalia-dev/noctalia-docs) after merge, or this PR does not change user-facing configuration or behavior.
- [x] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes

New configuration options are located under `[appearence]`:

```toml
[appearance]
hide_session_selector = true
hide_scheme_selector = true
hide_shutdown_button = true
hide_reboot_button = true
hide_firmware_button = true
```