### PR TITLE
Feat/output identity selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Noctalia Greeter
-===
+# Noctalia Greeter
 
 A minimal login greeter for [greetd](https://github.com/kennylevinsen/greetd) that matches the look and feel of [Noctalia Shell](https://github.com/noctalia-dev/noctalia-shell).
 
@@ -265,16 +264,37 @@ Sessions come from `wayland-sessions` `.desktop` files under `/usr/share`, each 
 
 ### Multi-monitor
 
-By default the greeter is **mirrored on every connected monitor** (same UI on each display, each sized to that output's own resolution and scale). To pin it to a single connector, set `[output].name` in `/var/lib/noctalia-greeter/greeter.toml`:
+By default the greeter is **mirrored on every connected monitor** (same UI on each display, each sized to that output's own resolution and scale). To pin it to one display, set `[output].name` in `/var/lib/noctalia-greeter/greeter.toml`:
 
 ```toml
 [output]
 name = "DP-2"
 ```
 
-The compositor disables the other connectors at the KMS level when `[output].name` is set. If it names a disconnected connector, the greeter falls back to mirroring on all outputs.
+`name` can match any of the exact values of the display connector, description, make, model, or serial number. `noctalia-greeter outputs` prints `CONNECTOR - MAKE - MODEL - SERIAL`. For example, using a serial number:
 
-When using multiple monitors, set `[output].layout` manually or sync from Noctalia Shell (see Matching Noctalia Shell). Without it, outputs are placed left-to-right by connector name. Portrait panels need `[output].transforms` (also synced from the shell) so the greeter UI is upright. List connector names with `noctalia-greeter outputs`:
+```toml
+[output]
+name = "CVN12345"
+```
+
+Or a connector:
+
+```toml
+[output]
+name = "HDMI-A-1"
+```
+
+Or a description:
+
+```toml
+[output]
+name = "LG TV SSCR2"
+```
+
+The compositor disables the other connectors at the KMS level when `[output].name` selects exactly one output. If it has no match or matches multiple outputs, the greeter logs the reason and falls back to mirroring on all outputs.
+
+When using multiple monitors, set `[output].layout` manually or sync from Noctalia Shell (see Matching Noctalia Shell). Without it, outputs are placed left-to-right by connector name. Portrait panels need `[output].transforms` (also synced from the shell) so the greeter UI is upright. Layout and transform maps still use connector names. List output identities with `noctalia-greeter outputs` (the serial field is empty when the compositor does not expose output management):
 
 ```toml
 [output]
@@ -312,7 +332,7 @@ timeout = 300
 
 On NixOS: `programs.noctalia-greeter.settings.idle.timeout = 300;` (written to `greeter.toml`).
 
-List connector names from a running Wayland session:
+List output identities from a running Wayland session:
 
 ```sh
 noctalia-greeter outputs
@@ -420,16 +440,16 @@ command = "env XKB_DEFAULT_LAYOUT=cz /usr/bin/noctalia-greeter-session"
 
 ### Shortcuts
 
-| Key | Action |
-|-----|--------|
-| `Tab` / `Shift+Tab` | Move focus |
-| `↑` / `↓` | Move focus, or move in an open menu |
-| `Enter` | Submit password / activate / confirm menu |
-| `Space` | Activate focused control |
-| `Esc` | Close menu or leave password step |
-| `F3` | Session picker |
-| `F7` | Color scheme picker |
-| `Ctrl+Alt+F1`-`F12` | Switch to virtual terminal (TTY) |
+| Key                 | Action                                    |
+| ------------------- | ----------------------------------------- |
+| `Tab` / `Shift+Tab` | Move focus                                |
+| `↑` / `↓`           | Move focus, or move in an open menu       |
+| `Enter`             | Submit password / activate / confirm menu |
+| `Space`             | Activate focused control                  |
+| `Esc`               | Close menu or leave password step         |
+| `F3`                | Session picker                            |
+| `F7`                | Color scheme picker                       |
+| `Ctrl+Alt+F1`-`F12` | Switch to virtual terminal (TTY)          |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ It is built for **greetd**: greetd starts the bundled wlroots compositor (`nocta
 
 Pair it with **[Noctalia v5](https://github.com/noctalia-dev/noctalia)** if you want wallpaper and palette synced from the shell settings (optional).
 
+## PAM autologin
+
+To have the greeter authenticate a configured account immediately, set both values below:
+
+```toml
+[user]
+default = "your-user"
+
+[auth]
+autologin = true
+```
+
+This is authenticated autologin: the greeter calls greetd's normal `create_session`
+flow, so PAM modules such as `pam_systemd_loadkey` and `pam_gnome_keyring` can use a
+LUKS passphrase retained by the systemd initrd. It never submits an empty password.
+If PAM asks for input or rejects the login, the normal password screen remains available.
+
 ## Dependencies
 
 Install everything below on the machine where greetd will run. Each list covers build tools and libraries, plus **greetd** and **D-Bus** (used by `noctalia-greeter-session`). You still need your desktop sessions separately (niri, Hyprland, and so on).

--- a/examples/greeter.toml
+++ b/examples/greeter.toml
@@ -101,3 +101,7 @@ numlock = true
 [auth]
 # Allow empty password submit (fprintd / smartcard PAM). Default false.
 allow_empty_password = false
+# Authenticate [user].default immediately. This runs greetd's PAM stack, so
+# pam_systemd_loadkey can unlock a matching GNOME Keyring after LUKS. If PAM
+# asks for input or authentication fails, the normal password screen is shown.
+autologin = false

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ foreach _p : [
   ['cursor-shape-v1', 'protocols/cursor-shape-v1.xml'],
   ['fractional-scale-v1', wayland_protos_dir / 'staging/fractional-scale/fractional-scale-v1.xml'],
   ['viewporter', wayland_protos_dir / 'stable/viewporter/viewporter.xml'],
+  ['wlr-output-management-unstable-v1', 'protocols/wlr-output-management-unstable-v1.xml'],
 ]
   _name = _p[0]
   _xml  = _p[1]

--- a/protocols/wlr-output-management-unstable-v1.xml
+++ b/protocols/wlr-output-management-unstable-v1.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Client subset of wlroots' wlr-output-management-unstable-v1 protocol. -->
+<protocol name="wlr_output_management_unstable_v1">
+  <interface name="zwlr_output_manager_v1" version="3">
+    <event name="head"><arg name="head" type="new_id" interface="zwlr_output_head_v1"/></event>
+    <event name="done"><arg name="serial" type="uint"/></event>
+    <request name="create_configuration"><arg name="id" type="new_id" interface="zwlr_output_configuration_v1"/><arg name="serial" type="uint"/></request>
+    <request name="stop"/>
+    <event name="finished" type="destructor"/>
+  </interface>
+  <interface name="zwlr_output_head_v1" version="3">
+    <event name="name"><arg name="name" type="string"/></event>
+    <event name="description"><arg name="description" type="string"/></event>
+    <event name="physical_size"><arg name="width" type="int"/><arg name="height" type="int"/></event>
+    <event name="mode"><arg name="mode" type="new_id" interface="zwlr_output_mode_v1"/></event>
+    <event name="enabled"><arg name="enabled" type="int"/></event>
+    <event name="current_mode"><arg name="mode" type="object" interface="zwlr_output_mode_v1"/></event>
+    <event name="position"><arg name="x" type="int"/><arg name="y" type="int"/></event>
+    <event name="transform"><arg name="transform" type="int"/></event>
+    <event name="scale"><arg name="scale" type="fixed"/></event>
+    <event name="finished"/>
+    <event name="make" since="2"><arg name="make" type="string"/></event>
+    <event name="model" since="2"><arg name="model" type="string"/></event>
+    <event name="serial_number" since="2"><arg name="serial_number" type="string"/></event>
+    <request name="release" type="destructor" since="3"/>
+  </interface>
+  <interface name="zwlr_output_mode_v1" version="3">
+    <event name="size"><arg name="width" type="int"/><arg name="height" type="int"/></event>
+    <event name="refresh"><arg name="refresh" type="int"/></event>
+    <event name="preferred"/>
+    <event name="finished"/>
+    <request name="release" type="destructor" since="3"/>
+  </interface>
+  <interface name="zwlr_output_configuration_v1" version="1">
+    <request name="enable_head"><arg name="id" type="new_id" interface="zwlr_output_configuration_head_v1"/><arg name="head" type="object" interface="zwlr_output_head_v1"/></request>
+    <request name="disable_head"><arg name="head" type="object" interface="zwlr_output_head_v1"/></request>
+    <request name="apply"/>
+    <request name="test"/>
+    <request name="destroy" type="destructor"/>
+    <event name="succeeded"/>
+    <event name="failed"/>
+    <event name="cancelled"/>
+  </interface>
+  <interface name="zwlr_output_configuration_head_v1" version="1">
+    <request name="set_mode"><arg name="mode" type="object" interface="zwlr_output_mode_v1"/></request>
+    <request name="set_custom_mode"><arg name="width" type="int"/><arg name="height" type="int"/><arg name="refresh" type="int"/></request>
+    <request name="set_position"><arg name="x" type="int"/><arg name="y" type="int"/></request>
+    <request name="set_transform"><arg name="transform" type="int"/></request>
+    <request name="set_scale"><arg name="scale" type="fixed"/></request>
+  </interface>
+</protocol>

--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -12,9 +12,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 #include <sys/timerfd.h>
 #include <sys/wait.h>
+#include <syslog.h>
 #include <time.h>
 #include <unistd.h>
 #include <wayland-server-core.h>
@@ -33,6 +33,7 @@
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_seat.h>
@@ -233,6 +234,7 @@ struct greeter_server {
   struct greeter_output_placement output_placements[16];
   size_t output_placement_count;
   struct wlr_fractional_scale_manager_v1* fractional_scale;
+  struct wlr_output_manager_v1* output_manager;
   bool shutting_down;
 };
 
@@ -684,7 +686,7 @@ notify_surface_scale(struct greeter_server* server, struct wlr_surface* surface,
 
 static bool use_all_outputs(const struct greeter_server* server) { return server->preferred_output[0] == '\0'; }
 
-static struct greeter_output* output_by_name(struct greeter_server* server, const char* name) {
+static struct greeter_output* output_by_connector(struct greeter_server* server, const char* name) {
   struct greeter_output* output;
   wl_list_for_each(output, &server->outputs, link) {
     if (strcmp(output->wlr_output->name, name) == 0) {
@@ -692,6 +694,52 @@ static struct greeter_output* output_by_name(struct greeter_server* server, cons
     }
   }
   return NULL;
+}
+
+static bool contains_output_token(const char* value, const char* token) {
+  if (value == NULL || value[0] == '\0' || token == NULL || token[0] == '\0') {
+    return false;
+  }
+
+  const size_t token_len = strlen(token);
+  const char* match = value;
+  while ((match = strstr(match, token)) != NULL) {
+    const bool starts_token = match == value || isspace((unsigned char)match[-1]);
+    const char after = match[token_len];
+    const bool ends_token = after == '\0' || isspace((unsigned char)after);
+    if (starts_token && ends_token) {
+      return true;
+    }
+    match += token_len;
+  }
+  return false;
+}
+
+static bool output_matches_selector(const struct wlr_output* output, const char* selector) {
+  return strcmp(output->name, selector) == 0
+      || contains_output_token(output->description, selector)
+      || contains_output_token(output->make, selector)
+      || contains_output_token(output->model, selector)
+      || contains_output_token(output->serial, selector);
+}
+
+static struct greeter_output* output_by_selector(struct greeter_server* server, const char* selector) {
+  struct greeter_output* result = NULL;
+  struct greeter_output* output;
+  wl_list_for_each(output, &server->outputs, link) {
+    if (!output_matches_selector(output->wlr_output, selector)) {
+      continue;
+    }
+    if (result != NULL) {
+      wlr_log(WLR_INFO, "output selector '%s' is ambiguous; using all outputs", selector);
+      return NULL;
+    }
+    result = output;
+  }
+  if (result == NULL) {
+    wlr_log(WLR_INFO, "output selector '%s' not connected; using all outputs", selector);
+  }
+  return result;
 }
 
 static bool any_output_active(const struct greeter_server* server) {
@@ -702,6 +750,24 @@ static bool any_output_active(const struct greeter_server* server) {
     }
   }
   return false;
+}
+
+static void publish_output_configuration(struct greeter_server* server) {
+  if (server->output_manager == NULL) {
+    return;
+  }
+  struct wlr_output_configuration_v1* config = wlr_output_configuration_v1_create();
+  if (config == NULL) {
+    return;
+  }
+  struct greeter_output* output;
+  wl_list_for_each(output, &server->outputs, link) {
+    struct wlr_output_configuration_head_v1* head = wlr_output_configuration_head_v1_create(config, output->wlr_output);
+    if (head != NULL) {
+      head->state.enabled = output->active;
+    }
+  }
+  wlr_output_manager_v1_set_configuration(server->output_manager, config);
 }
 
 static int compare_greeter_output_ptr(const void* a, const void* b) {
@@ -783,7 +849,7 @@ static bool layout_output_at(struct greeter_output* output, int layout_x, int la
 static void layout_outputs_from_config(struct greeter_server* server) {
   for (size_t i = 0; i < server->output_placement_count; ++i) {
     const struct greeter_output_placement* cfg = &server->output_placements[i];
-    struct greeter_output* output = output_by_name(server, cfg->name);
+    struct greeter_output* output = output_by_connector(server, cfg->name);
     if (output == NULL) {
       wlr_log(WLR_INFO, "output_layout: '%s' not connected", cfg->name);
       continue;
@@ -1205,7 +1271,7 @@ static void warp_cursor_to_output_center(struct greeter_server* server, struct g
 
 static void warp_cursor_to_initial_position(struct greeter_server* server) {
   if (!use_all_outputs(server)) {
-    struct greeter_output* pinned = output_by_name(server, server->preferred_output);
+    struct greeter_output* pinned = output_by_selector(server, server->preferred_output);
     if (pinned != NULL && pinned->active) {
       warp_cursor_to_output_center(server, pinned);
       return;
@@ -1301,9 +1367,8 @@ static void choose_outputs(struct greeter_server* server) {
   bool use_all = use_all_outputs(server);
   struct greeter_output* pinned = NULL;
   if (!use_all) {
-    pinned = output_by_name(server, server->preferred_output);
+    pinned = output_by_selector(server, server->preferred_output);
     if (pinned == NULL) {
-      wlr_log(WLR_INFO, "output '%s' not connected; using all outputs", server->preferred_output);
       use_all = true;
     }
   }
@@ -1349,6 +1414,7 @@ static void choose_outputs(struct greeter_server* server) {
   if (any_output_active(server)) {
     warp_cursor_to_initial_position(server);
   }
+  publish_output_configuration(server);
   schedule_launch(server);
   schedule_output_frames(server);
 }
@@ -2079,6 +2145,7 @@ int main(int argc, char** argv) {
   wlr_data_device_manager_create(server.display);
   wlr_viewporter_create(server.display);
   server.fractional_scale = wlr_fractional_scale_manager_v1_create(server.display, 1);
+  server.output_manager = wlr_output_manager_v1_create(server.display);
   server.output_layout = wlr_output_layout_create(server.display);
   server.scene = wlr_scene_create();
   server.scene_output_layout = wlr_scene_attach_output_layout(server.scene, server.output_layout);

--- a/src/greeter/greeter.cpp
+++ b/src/greeter/greeter.cpp
@@ -243,6 +243,7 @@ void Greeter::syncOutputWindows() {
     View view;
     view.surface = std::make_unique<GreeterSurface>();
     view.surface->setGreetdClient(&m_greetdClient);
+    view.surface->setAutoLoginAllowed(m_views.empty());
     view.surface->setOnExitRequested([this]() { m_exitRequested = true; });
     view.surface->setOnStateChanged([this](GreeterSurface* source) { syncStateFrom(source); });
     view.surface->initialize(m_renderContext.get());

--- a/src/greeter/greeter.cpp
+++ b/src/greeter/greeter.cpp
@@ -38,23 +38,11 @@ namespace {
   }
 
   void applyConfiguredOutput(WaylandClient& client, const std::optional<std::string>& configured) {
-    if (!configured.has_value() || configured->empty()) {
-      client.forgetPreferredOutput();
-      return;
-    }
-
-    client.setPreferredOutputName(configured);
-    if (!client.hasReadyOutputs()) {
-      return;
-    }
-
-    if (!client.hasResolvedPreferredOutput()) {
-      kLog.warn("output '{}' is not connected; showing on all outputs", *configured);
-      client.forgetPreferredOutput();
-      return;
-    }
-
-    kLog.info("preferred output connector: {}", *configured);
+    // The greeter compositor resolves [output].name before clients connect.
+    // Do not reinterpret an identity selector here: wl_output does not expose
+    // serial numbers, and a client-side fallback could disagree with the compositor.
+    (void)configured;
+    client.forgetPreferredOutput();
   }
 } // namespace
 

--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -20,9 +20,8 @@ namespace {
 
   void recordParseError(const std::filesystem::path& path, const toml::parse_error& error) {
     const auto source = error.source();
-    const auto existing = std::ranges::find_if(g_diagnostics, [&path](const auto& diagnostic) {
-      return diagnostic.path == path;
-    });
+    const auto existing =
+        std::ranges::find_if(g_diagnostics, [&path](const auto& diagnostic) { return diagnostic.path == path; });
     if (existing != g_diagnostics.end()) {
       return;
     }
@@ -87,7 +86,9 @@ namespace {
     return key == "layout" || key == "variant" || key == "options" || key == "numlock";
   }
 
-  [[nodiscard]] bool isKnownAuthKey(std::string_view key) { return key == "allow_empty_password"; }
+  [[nodiscard]] bool isKnownAuthKey(std::string_view key) {
+    return key == "allow_empty_password" || key == "autologin";
+  }
 
   [[nodiscard]] std::optional<std::string> stringValue(const toml::node& node) {
     if (const auto value = node.value<std::string>()) {
@@ -334,7 +335,11 @@ namespace {
             continue;
           }
           if (const auto value = entryNode.value<bool>()) {
-            config.authAllowEmptyPassword = *value;
+            if (entryView == "allow_empty_password") {
+              config.authAllowEmptyPassword = *value;
+            } else {
+              config.authAutoLogin = *value;
+            }
           }
         }
       }
@@ -551,6 +556,13 @@ namespace {
     if (config.authAllowEmptyPassword.has_value()) {
       toml::table auth;
       auth.insert_or_assign("allow_empty_password", *config.authAllowEmptyPassword);
+      if (config.authAutoLogin.has_value()) {
+        auth.insert_or_assign("autologin", *config.authAutoLogin);
+      }
+      root.insert("auth", std::move(auth));
+    } else if (config.authAutoLogin.has_value()) {
+      toml::table auth;
+      auth.insert_or_assign("autologin", *config.authAutoLogin);
       root.insert("auth", std::move(auth));
     }
 
@@ -797,7 +809,7 @@ namespace greeter::config {
     out << "# [appearance.wallpapers.<connector>] per-output wallpaper overrides\n";
     out << "# [output] name/layout/scale/scales/width/height/transforms, [idle] timeout, [cursor] theme/size/path\n";
     out << "# [keyboard] layout/variant/options/numlock\n";
-    out << "# [auth] allow_empty_password (bool, default false; enables fingerprint/smartcard PAM auth)\n";
+    out << "# [auth] allow_empty_password, autologin (bool; autologin requires [user].default)\n";
     out << '\n';
     out << formatToml(table);
 

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -70,6 +70,7 @@ namespace greeter::config {
     std::optional<bool> keyboardNumlock;
 
     std::optional<bool> authAllowEmptyPassword;
+    std::optional<bool> authAutoLogin;
   };
 
   // Sync + UI mutable file (sync.toml). Never managed by Nix. Loses to greeter.toml.

--- a/src/greeter/greeter_preferences.cpp
+++ b/src/greeter/greeter_preferences.cpp
@@ -448,6 +448,9 @@ namespace greeter {
     if (file.authAllowEmptyPassword.has_value()) {
       prefs.allowEmptyPassword = *file.authAllowEmptyPassword;
     }
+    if (file.authAutoLogin.has_value()) {
+      prefs.autoLogin = *file.authAutoLogin;
+    }
     return prefs;
   }
 

--- a/src/greeter/greeter_preferences.h
+++ b/src/greeter/greeter_preferences.h
@@ -31,6 +31,7 @@ namespace greeter {
     std::optional<float> scale;
     PasswordMaskStyle passwordMaskStyle = PasswordMaskStyle::Default;
     bool allowEmptyPassword = false;
+    bool autoLogin = false;
     bool hideLogo = false;
   };
 

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -6,8 +6,8 @@
 #include "core/log.h"
 #include "core/resource_paths.h"
 #include "greeter/appearance_config.h"
-#include "greeter/greeter_config_store.h"
 #include "greeter/appearance_sync.h"
+#include "greeter/greeter_config_store.h"
 #include "greeter/greeter_preferences.h"
 #include "greeter/greeter_sessions.h"
 #include "greeter/greeter_window.h"
@@ -599,6 +599,7 @@ void GreeterSurface::initialize(RenderContext* context) {
   applyScheme(m_selectedScheme);
   refreshSelectionLabels();
   applyInitialUserSelection();
+  tryAutoLogin();
 
   if (const auto& diagnostics = greeter::config::configDiagnostics(); !diagnostics.empty()) {
     const auto& diagnostic = diagnostics.front();
@@ -723,6 +724,8 @@ void GreeterSurface::reconcileKeyboardFocus() {
 void GreeterSurface::setWindow(GreeterWindow* window) { m_window = window; }
 
 void GreeterSurface::setGreetdClient(GreetdClient* client) { m_greetdClient = client; }
+
+void GreeterSurface::setAutoLoginAllowed(const bool allowed) noexcept { m_autoLoginAllowed = allowed; }
 
 void GreeterSurface::setUsername(const std::string& username) { m_username = username; }
 
@@ -1169,9 +1172,7 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
         }
     );
     m_configErrorHeading->setPosition(bannerX + padding, bannerY + padding);
-    m_configErrorLabel->setPosition(
-        bannerX + padding, bannerY + padding + m_configErrorHeading->height() + gap
-    );
+    m_configErrorLabel->setPosition(bannerX + padding, bannerY + padding + m_configErrorHeading->height() + gap);
   }
 
   syncHeaderUserAvatar(*renderer, headerGlyphSize, panelX, panelWidth, headerY);
@@ -1359,6 +1360,26 @@ void GreeterSurface::tryAuthenticate() {
   } else if (m_secretPromptWaiting) {
     postAuthResponse(m_password);
   }
+}
+
+void GreeterSurface::tryAutoLogin() {
+  if (!m_autoLogin || !m_autoLoginAllowed) {
+    return;
+  }
+  if (m_greetdClient == nullptr || !m_greetdClient->isConnected() || m_username.empty()) {
+    kLog.warn("autologin requires a connected greetd client and [user].default; showing the login screen");
+    return;
+  }
+
+  m_authenticating = true;
+  kLog.info("greetd: autologin create_session for '{}'", m_username);
+  if (!m_greetdClient->requestCreateSession(m_username)) {
+    onAuthError(m_greetdClient->lastError().value_or(GreetdError{GreetdErrorType::Error, "failed to send request"}));
+    return;
+  }
+  m_authSessionStarted = true;
+  m_pendingReplies.push_back(AuthRequest::CreateSession);
+  syncAuthInteractivity();
 }
 
 void GreeterSurface::onGreetdReadable() {
@@ -1908,6 +1929,12 @@ void GreeterSurface::syncWallpaperTexture() {
 void GreeterSurface::loadPreferences() {
   const auto prefs = greeter::loadGreeterPreferences();
   m_allowEmptyPassword = prefs.allowEmptyPassword;
+  // Autologin is deliberately tied to the declarative user setting. A CLI
+  // --user or a single discovered account must never enable it implicitly.
+  m_autoLogin = prefs.autoLogin && prefs.defaultUser.has_value() && !prefs.defaultUser->empty();
+  if (prefs.autoLogin && !m_autoLogin) {
+    kLog.warn("[auth].autologin requires an explicit [user].default; showing the login screen");
+  }
   const auto initialSession = greeter::resolveInitialSessionName(prefs);
 
   if (initialSession.has_value()) {

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -45,6 +45,8 @@ public:
   void setWindow(GreeterWindow* window);
   void setBoundOutputName(std::string outputName);
   void setGreetdClient(GreetdClient* client);
+  // Only one output view may own greetd's single authentication conversation.
+  void setAutoLoginAllowed(bool allowed) noexcept;
   void setUsername(const std::string& username);
   void setOnExitRequested(std::function<void()> callback);
   void setOnStateChanged(std::function<void(GreeterSurface*)> callback);
@@ -82,6 +84,7 @@ private:
   void syncScaledTypography();
   void layoutScene(std::uint32_t width, std::uint32_t height);
   void tryAuthenticate();
+  void tryAutoLogin();
   void handleGreetdResponse(const GreetdResponse& response);
   void handleAuthMessage(const GreetdAuthMessage& message);
   void postAuthResponse(const std::string& data);
@@ -206,6 +209,8 @@ private:
   bool m_canRebootToFirmware = false;
 
   bool m_allowEmptyPassword = false;
+  bool m_autoLogin = false;
+  bool m_autoLoginAllowed = true;
 
   // greetd replies in request order, so m_pendingReplies (a FIFO of these) tells
   // which request each reply answers.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,9 @@ int main(int argc, char* argv[]) {
       if (!output.done || output.name.empty()) {
         continue;
       }
-      std::printf("%s\n", output.name.c_str());
+      std::printf(
+          "%s - %s - %s - %s\n", output.name.c_str(), output.make.c_str(), output.model.c_str(), output.serial.c_str()
+      );
       any = true;
     }
     if (!any) {
@@ -153,7 +155,7 @@ int main(int argc, char* argv[]) {
           "\n"
           "Commands:\n"
           "  sessions              List available session names and exit\n"
-          "  outputs               List Wayland connector names and exit\n"
+          "  outputs               List Wayland output identities and exit\n"
           "\n"
           "Options:\n"
           "  -h, --help            Show this help message\n"

--- a/src/wayland/wayland_client.cpp
+++ b/src/wayland/wayland_client.cpp
@@ -4,6 +4,7 @@
 #include "fractional-scale-v1-client-protocol.h"
 #include "greeter/greeter_preferences.h"
 #include "viewporter-client-protocol.h"
+#include "wlr-output-management-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
 #include <algorithm>
@@ -126,6 +127,50 @@ namespace {
       .scale = &WaylandClient::handleOutputScale,
       .name = &WaylandClient::handleOutputName,
       .description = &WaylandClient::handleOutputDescription,
+  };
+
+  void ignoreOutputHeadPhysicalSize(void*, zwlr_output_head_v1*, std::int32_t, std::int32_t) {}
+  void handleOutputHeadMode(void* data, zwlr_output_head_v1*, zwlr_output_mode_v1* mode);
+  void ignoreOutputHeadMode(void*, zwlr_output_head_v1*, zwlr_output_mode_v1*) {}
+  void ignoreOutputHeadEnabled(void*, zwlr_output_head_v1*, std::int32_t) {}
+  void ignoreOutputHeadPosition(void*, zwlr_output_head_v1*, std::int32_t, std::int32_t) {}
+  void ignoreOutputHeadTransform(void*, zwlr_output_head_v1*, std::int32_t) {}
+  void ignoreOutputHeadScale(void*, zwlr_output_head_v1*, wl_fixed_t) {}
+  void ignoreOutputModeSize(void*, zwlr_output_mode_v1*, std::int32_t, std::int32_t) {}
+  void ignoreOutputModeRefresh(void*, zwlr_output_mode_v1*, std::int32_t) {}
+  void ignoreOutputModePreferred(void*, zwlr_output_mode_v1*) {}
+
+  const zwlr_output_mode_v1_listener kOutputModeListener = {
+      .size = &ignoreOutputModeSize,
+      .refresh = &ignoreOutputModeRefresh,
+      .preferred = &ignoreOutputModePreferred,
+      .finished = &WaylandClient::handleOutputModeFinished,
+  };
+
+  const zwlr_output_head_v1_listener kOutputHeadListener = {
+      .name = &WaylandClient::handleOutputHeadName,
+      .description = &WaylandClient::handleOutputHeadDescription,
+      .physical_size = &ignoreOutputHeadPhysicalSize,
+      .mode = &handleOutputHeadMode,
+      .enabled = &ignoreOutputHeadEnabled,
+      .current_mode = &ignoreOutputHeadMode,
+      .position = &ignoreOutputHeadPosition,
+      .transform = &ignoreOutputHeadTransform,
+      .scale = &ignoreOutputHeadScale,
+      .finished = &WaylandClient::handleOutputHeadFinished,
+      .make = &WaylandClient::handleOutputHeadMake,
+      .model = &WaylandClient::handleOutputHeadModel,
+      .serial_number = &WaylandClient::handleOutputHeadSerial,
+  };
+
+  void handleOutputHeadMode(void* data, zwlr_output_head_v1*, zwlr_output_mode_v1* mode) {
+    zwlr_output_mode_v1_add_listener(mode, &kOutputModeListener, data);
+  }
+
+  const zwlr_output_manager_v1_listener kOutputManagerListener = {
+      .head = &WaylandClient::handleOutputManagerHead,
+      .done = &WaylandClient::handleOutputManagerDone,
+      .finished = &WaylandClient::handleOutputManagerFinished,
   };
 
   void logWaylandConnectDiagnostics() {
@@ -255,6 +300,12 @@ bool WaylandClient::connect() {
 
 void WaylandClient::disconnect() {
   m_seatHandler.cleanup();
+
+  if (m_outputManager != nullptr) {
+    zwlr_output_manager_v1_stop(m_outputManager);
+    m_outputManager = nullptr;
+  }
+  m_pendingOutputHeads.clear();
 
   if (m_xdgWmBase != nullptr) {
     xdg_wm_base_destroy(m_xdgWmBase);
@@ -677,7 +728,7 @@ void WaylandClient::notifyOutputsChanged() {
 
 void WaylandClient::handleOutputGeometry(
     void* data, wl_output* wlOut, std::int32_t x, std::int32_t y, std::int32_t physWidth, std::int32_t physHeight,
-    std::int32_t /*subpixel*/, const char* /*make*/, const char* /*model*/, std::int32_t /*transform*/
+    std::int32_t /*subpixel*/, const char* make, const char* model, std::int32_t /*transform*/
 ) {
   auto* client = static_cast<WaylandClient*>(data);
   for (auto& out : client->m_outputs) {
@@ -690,6 +741,8 @@ void WaylandClient::handleOutputGeometry(
     out.y = y;
     out.physicalWidthMm = physWidth;
     out.physicalHeightMm = physHeight;
+    out.make = make != nullptr ? make : "";
+    out.model = model != nullptr ? model : "";
     if (changed && out.done) {
       client->notifyOutputsChanged();
     }
@@ -756,12 +809,104 @@ void WaylandClient::handleOutputName(void* data, wl_output* wlOut, const char* n
   for (auto& out : client->m_outputs) {
     if (out.output == wlOut) {
       out.name = name;
+      client->matchPendingOutputHeads();
       break;
     }
   }
 }
 
-void WaylandClient::handleOutputDescription(void* /*data*/, wl_output* /*output*/, const char* /*description*/) {}
+void WaylandClient::handleOutputDescription(void* data, wl_output* wlOut, const char* description) {
+  auto* client = static_cast<WaylandClient*>(data);
+  for (auto& out : client->m_outputs) {
+    if (out.output == wlOut) {
+      out.description = description != nullptr ? description : "";
+      break;
+    }
+  }
+}
+
+void WaylandClient::matchPendingOutputHeads() {
+  for (const PendingOutputHead& head : m_pendingOutputHeads) {
+    if (head.name.empty()) {
+      continue;
+    }
+    for (auto& output : m_outputs) {
+      if (output.name != head.name) {
+        continue;
+      }
+      output.description = head.description;
+      output.make = head.make;
+      output.model = head.model;
+      output.serial = head.serial;
+      break;
+    }
+  }
+}
+
+void WaylandClient::handleOutputManagerHead(void* data, zwlr_output_manager_v1*, zwlr_output_head_v1* head) {
+  auto* client = static_cast<WaylandClient*>(data);
+  client->m_pendingOutputHeads.push_back({head, {}, {}, {}, {}, {}});
+  zwlr_output_head_v1_add_listener(head, &kOutputHeadListener, client);
+}
+
+void WaylandClient::handleOutputManagerDone(void* data, zwlr_output_manager_v1*, std::uint32_t) {
+  static_cast<WaylandClient*>(data)->matchPendingOutputHeads();
+}
+
+void WaylandClient::handleOutputManagerFinished(void* data, zwlr_output_manager_v1*) {
+  static_cast<WaylandClient*>(data)->m_outputManager = nullptr;
+}
+
+void WaylandClient::handleOutputHeadName(void* data, zwlr_output_head_v1* head, const char* name) {
+  auto* client = static_cast<WaylandClient*>(data);
+  for (auto& pending : client->m_pendingOutputHeads)
+    if (pending.head == head)
+      pending.name = name != nullptr ? name : "";
+}
+
+void WaylandClient::handleOutputHeadDescription(void* data, zwlr_output_head_v1* head, const char* description) {
+  auto* client = static_cast<WaylandClient*>(data);
+  for (auto& pending : client->m_pendingOutputHeads)
+    if (pending.head == head)
+      pending.description = description != nullptr ? description : "";
+}
+
+void WaylandClient::handleOutputHeadMake(void* data, zwlr_output_head_v1* head, const char* make) {
+  auto* client = static_cast<WaylandClient*>(data);
+  for (auto& pending : client->m_pendingOutputHeads)
+    if (pending.head == head)
+      pending.make = make != nullptr ? make : "";
+}
+
+void WaylandClient::handleOutputHeadModel(void* data, zwlr_output_head_v1* head, const char* model) {
+  auto* client = static_cast<WaylandClient*>(data);
+  for (auto& pending : client->m_pendingOutputHeads)
+    if (pending.head == head)
+      pending.model = model != nullptr ? model : "";
+}
+
+void WaylandClient::handleOutputHeadSerial(void* data, zwlr_output_head_v1* head, const char* serial) {
+  auto* client = static_cast<WaylandClient*>(data);
+  for (auto& pending : client->m_pendingOutputHeads)
+    if (pending.head == head)
+      pending.serial = serial != nullptr ? serial : "";
+}
+
+void WaylandClient::handleOutputHeadFinished(void* data, zwlr_output_head_v1* head) {
+  auto* client = static_cast<WaylandClient*>(data);
+  std::erase_if(client->m_pendingOutputHeads, [head](const PendingOutputHead& pending) {
+    return pending.head == head;
+  });
+  if (wl_proxy_get_version(reinterpret_cast<wl_proxy*>(head)) >= 3) {
+    zwlr_output_head_v1_release(head);
+  }
+}
+
+void WaylandClient::handleOutputModeFinished(void*, zwlr_output_mode_v1* mode) {
+  if (wl_proxy_get_version(reinterpret_cast<wl_proxy*>(mode)) >= 3) {
+    zwlr_output_mode_v1_release(mode);
+  }
+}
 
 void WaylandClient::bindOutput(wl_registry* registry, std::uint32_t name, std::uint32_t version) {
   const std::uint32_t bindVersion = std::min(version, 4u);
@@ -814,6 +959,14 @@ void WaylandClient::bindGlobal(
 
   if (interfaceName == wl_output_interface.name) {
     bindOutput(registry, name, version);
+    return;
+  }
+
+  if (interfaceName == zwlr_output_manager_v1_interface.name) {
+    m_outputManager = static_cast<zwlr_output_manager_v1*>(
+        wl_registry_bind(registry, name, &zwlr_output_manager_v1_interface, std::min(version, 3u))
+    );
+    zwlr_output_manager_v1_add_listener(m_outputManager, &kOutputManagerListener, this);
     return;
   }
 

--- a/src/wayland/wayland_client.h
+++ b/src/wayland/wayland_client.h
@@ -19,6 +19,9 @@ struct wl_seat;
 struct wp_fractional_scale_manager_v1;
 struct wp_viewporter;
 struct xdg_wm_base;
+struct zwlr_output_head_v1;
+struct zwlr_output_manager_v1;
+struct zwlr_output_mode_v1;
 
 struct WaylandOutputLayout {
   int32_t x = 0;
@@ -31,6 +34,10 @@ struct WaylandOutputInfo {
   wl_output* output = nullptr;
   std::uint32_t registryName = 0;
   std::string name;
+  std::string description;
+  std::string make;
+  std::string model;
+  std::string serial;
   int32_t x = 0;
   int32_t y = 0;
   int32_t physicalWidthMm = 0;
@@ -113,10 +120,21 @@ public:
   static void handleOutputScale(void* data, wl_output* output, std::int32_t factor);
   static void handleOutputName(void* data, wl_output* output, const char* name);
   static void handleOutputDescription(void* data, wl_output* output, const char* description);
+  static void handleOutputManagerHead(void* data, zwlr_output_manager_v1* manager, zwlr_output_head_v1* head);
+  static void handleOutputManagerDone(void* data, zwlr_output_manager_v1* manager, std::uint32_t serial);
+  static void handleOutputManagerFinished(void* data, zwlr_output_manager_v1* manager);
+  static void handleOutputHeadName(void* data, zwlr_output_head_v1* head, const char* name);
+  static void handleOutputHeadDescription(void* data, zwlr_output_head_v1* head, const char* description);
+  static void handleOutputHeadMake(void* data, zwlr_output_head_v1* head, const char* make);
+  static void handleOutputHeadModel(void* data, zwlr_output_head_v1* head, const char* model);
+  static void handleOutputHeadSerial(void* data, zwlr_output_head_v1* head, const char* serial);
+  static void handleOutputHeadFinished(void* data, zwlr_output_head_v1* head);
+  static void handleOutputModeFinished(void* data, zwlr_output_mode_v1* mode);
 
 private:
   void bindGlobal(wl_registry* registry, std::uint32_t name, const char* interface, std::uint32_t version);
   void bindOutput(wl_registry* registry, std::uint32_t name, std::uint32_t version);
+  void matchPendingOutputHeads();
   [[nodiscard]] const WaylandOutputInfo* primaryOutput() const noexcept;
   [[nodiscard]] const WaylandOutputInfo* preferredOutput() const noexcept;
   [[nodiscard]] const WaylandOutputInfo* findOutputByName(std::string_view name) const noexcept;
@@ -131,6 +149,16 @@ private:
   xdg_wm_base* m_xdgWmBase = nullptr;
   wp_fractional_scale_manager_v1* m_fractionalScaleManager = nullptr;
   wp_viewporter* m_viewporter = nullptr;
+  zwlr_output_manager_v1* m_outputManager = nullptr;
+  struct PendingOutputHead {
+    zwlr_output_head_v1* head = nullptr;
+    std::string name;
+    std::string description;
+    std::string make;
+    std::string model;
+    std::string serial;
+  };
+  std::vector<PendingOutputHead> m_pendingOutputHeads;
   WaylandSeat m_seatHandler;
   std::vector<WaylandOutputInfo> m_outputs;
   std::vector<greeter::GreeterOutputPlacement> m_outputLayout;


### PR DESCRIPTION
## Summary

Today we can only pin the greeter config to a connector as name. This limits us on monitors we want to set independant of the connector we use. Based on https://github.com/noctalia-dev/noctalia/pull/3754 for noctalia-shell where we added support to match by make, serial number and description using the `zwlr_output_manager_v1` extension  we do something similar here to be able to match by different names.

As in the first one, happy to take feedbacks here on how we can do it differently.

## Motivation

We should be able to match by more than the connector as we can change the connector and set different monitors if we have multiple of the same name.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

Ran locally the outputs command:

```
$ build/noctalia-greeter outputs
HDMI-A-2 - LG Electronics - LG TV SSCR2 - 0x01010101
```

Copied the greeter and compositor to a VM and ran it looking for the logs for pinned output:
```
$ sudo tail -F /tmp/noctalia-greeter-test/greeter.log 2> /dev/null| grep 'greeter pinned output'
[wlr] [../src/compositor/noctalia_compositor.c:1405] greeter pinned output: Virtual-1
[wlr] [../src/compositor/noctalia_compositor.c:1405] greeter pinned output: Virtual-1
[wlr] [../src/compositor/noctalia_compositor.c:1405] greeter pinned output: Virtual-1
```

Whilst checking for logs, changed the config to multiple values, including the VM outputs for make, model and connector. Only the exact matches returned the log.

## Manual Coverage

- [X] Tested under greetd (real login flow)
- [X] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [X] Tested on NixOS (`programs.noctalia-greeter`)
- [X] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Screenshots / Videos

None 

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `AGENTS.md` and `README.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation in [noctalia-docs](https://github.com/noctalia-dev/noctalia-docs) after merge, or this PR does not change user-facing configuration or behavior.
- [X] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes
