### PR TITLE
feat(greeter): add position config for power buttons and scheme selector

### DIFF
--- a/src/greeter/greeter_config_io.cpp
+++ b/src/greeter/greeter_config_io.cpp
@@ -39,6 +39,8 @@ namespace {
     return key == "scheme"
         || key == "password_style"
         || key == "hide_logo"
+        || key == "power_buttons_position"
+        || key == "scheme_selector_position"
         || key == "theme_mode"
         || key == "corner_radius_scale"
         || key == "font_family"
@@ -188,6 +190,10 @@ namespace {
             if (const auto value = entryNode.value<bool>()) {
               config.appearanceHideLogo = *value;
             }
+          } else if (entryView == "power_buttons_position") {
+            config.appearancePowerButtonsPosition = stringValue(entryNode);
+          } else if (entryView == "scheme_selector_position") {
+            config.appearanceSchemeSelectorPosition = stringValue(entryNode);
           } else if (entryView == "theme_mode") {
             config.appearance.themeMode = stringValue(entryNode);
           } else if (entryView == "corner_radius_scale") {
@@ -437,6 +443,18 @@ namespace {
     if (config.appearanceHideLogo.has_value()) {
       appearance.insert_or_assign("hide_logo", *config.appearanceHideLogo);
     }
+    insertString(
+        appearance, "power_buttons_position", config.appearancePowerButtonsPosition,
+        [](toml::table& table, std::string_view key, const std::string& value) {
+          table.insert_or_assign(std::string(key), value);
+        }
+    );
+    insertString(
+        appearance, "scheme_selector_position", config.appearanceSchemeSelectorPosition,
+        [](toml::table& table, std::string_view key, const std::string& value) {
+          table.insert_or_assign(std::string(key), value);
+        }
+    );
     if (!appearance.empty()) {
       root.insert("appearance", std::move(appearance));
     }
@@ -770,7 +788,8 @@ namespace greeter::config {
     out << "# and output layout/transforms when not set here. Session power actions/menu entries are\n";
     out << "# Sync-only (sync.toml [session.power]/[[session.actions]]) and are not settable here.\n";
     out << "# [session] default, [user] default\n";
-    out << "# [appearance] scheme, password_style, hide_logo, theme_mode, corner_radius_scale, font_family\n";
+    out << "# [appearance] scheme, password_style, hide_logo, power_buttons_position, scheme_selector_position, "
+           "theme_mode, corner_radius_scale, font_family\n";
     out << "# [appearance.palette] full color role table, [appearance.wallpaper] path/fill_mode/fill_color\n";
     out << "# [appearance.wallpapers.<connector>] per-output wallpaper overrides\n";
     out << "# [output] name/layout/scale/scales/width/height/transforms, [idle] timeout, [cursor] theme/size/path\n";

--- a/src/greeter/greeter_config_store.h
+++ b/src/greeter/greeter_config_store.h
@@ -39,6 +39,9 @@ namespace greeter::config {
     std::optional<std::string> appearanceScheme;
     std::optional<std::string> appearancePasswordStyle;
     std::optional<bool> appearanceHideLogo;
+    // UI element positioning: "hidden", "bottom-left", "bottom-right", "top-left", "top-right"
+    std::optional<std::string> appearancePowerButtonsPosition;
+    std::optional<std::string> appearanceSchemeSelectorPosition;
     // Optional palette/wallpaper/font; wins over Sync sync.toml when complete.
     GreeterTomlAppearance appearance;
 

--- a/src/greeter/greeter_preferences.cpp
+++ b/src/greeter/greeter_preferences.cpp
@@ -445,6 +445,8 @@ namespace greeter {
     if (file.appearanceHideLogo.has_value()) {
       prefs.hideLogo = *file.appearanceHideLogo;
     }
+    prefs.powerButtonsPosition = file.appearancePowerButtonsPosition;
+    prefs.schemeSelectorPosition = file.appearanceSchemeSelectorPosition;
     if (file.authAllowEmptyPassword.has_value()) {
       prefs.allowEmptyPassword = *file.authAllowEmptyPassword;
     }

--- a/src/greeter/greeter_preferences.h
+++ b/src/greeter/greeter_preferences.h
@@ -32,6 +32,9 @@ namespace greeter {
     PasswordMaskStyle passwordMaskStyle = PasswordMaskStyle::Default;
     bool allowEmptyPassword = false;
     bool hideLogo = false;
+    // UI element positioning: "hidden", "bottom-left", "bottom-right", "top-left", "top-right"
+    std::optional<std::string> powerButtonsPosition;
+    std::optional<std::string> schemeSelectorPosition;
   };
 
   [[nodiscard]] std::filesystem::path greeterConfPath();

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -1126,12 +1126,37 @@ void GreeterSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
 
   const float selectorH = Style::controlHeightSm();
   const float schemeW = measureIconSelectorWidth(m_schemeSelectIcon, m_schemeSelectGlyph);
-  const float schemeX = ox + sw - schemeW - Style::spaceLg();
-  const float schemeY = oy + Style::spaceLg();
-  layoutSelector(
-      m_schemeSelectBox, m_schemeSelectIcon, m_schemeSelectGlyph, m_schemeSelectArea, schemeX, schemeY, schemeW,
-      selectorH
-  );
+
+  // Determine scheme selector position based on config
+  float schemeX;
+  float schemeY;
+  if (m_schemeSelectorPosition == "hidden") {
+    // Hide all selector parts (always non-null after initialize())
+    m_schemeSelectBox->setVisible(false);
+    m_schemeSelectIcon->setVisible(false);
+    m_schemeSelectGlyph->setVisible(false);
+    m_schemeSelectArea->setVisible(false);
+    m_schemeSelectLabel->setVisible(false);
+  } else {
+    if (m_schemeSelectorPosition == "top-left") {
+      schemeX = ox + Style::spaceLg();
+      schemeY = oy + Style::spaceLg();
+    } else if (m_schemeSelectorPosition == "bottom-left") {
+      schemeX = ox + Style::spaceLg();
+      schemeY = oy + sh - selectorH - Style::spaceLg();
+    } else if (m_schemeSelectorPosition == "bottom-right") {
+      schemeX = ox + sw - schemeW - Style::spaceLg();
+      schemeY = oy + sh - selectorH - Style::spaceLg();
+    } else {
+      // Default: top-right
+      schemeX = ox + sw - schemeW - Style::spaceLg();
+      schemeY = oy + Style::spaceLg();
+    }
+    layoutSelector(
+        m_schemeSelectBox, m_schemeSelectIcon, m_schemeSelectGlyph, m_schemeSelectArea, schemeX, schemeY, schemeW,
+        selectorH
+    );
+  }
   if (m_schemeSelectLabel != nullptr) {
     m_schemeSelectLabel->setVisible(false);
   }
@@ -1845,6 +1870,8 @@ void GreeterSurface::loadPreferences() {
   }
 
   m_hideLogo = prefs.hideLogo;
+  m_powerButtonsPosition = prefs.powerButtonsPosition.value_or("bottom-right");
+  m_schemeSelectorPosition = prefs.schemeSelectorPosition.value_or("top-right");
 }
 
 void GreeterSurface::savePreferences() const {
@@ -1904,6 +1931,12 @@ void GreeterSurface::toggleSessionMenu() {
 }
 
 void GreeterSurface::toggleSchemeMenu() {
+  // Don't toggle the menu if the selector is hidden
+  if (m_schemeSelectorPosition == "hidden" && m_schemeMenuOpen) {
+    m_schemeMenuOpen = false;
+    requestLayout();
+    return;
+  }
   m_schemeMenuOpen = !m_schemeMenuOpen;
   if (m_schemeMenuOpen) {
     m_userMenuOpen = false;
@@ -2012,17 +2045,17 @@ void GreeterSurface::rebuildFocusRing() {
   if (m_sessionSelectArea != nullptr) {
     m_focusRing.push_back({m_sessionSelectArea, [this]() { toggleSessionMenu(); }});
   }
-  if (m_schemeSelectArea != nullptr) {
+  if (m_schemeSelectArea != nullptr && m_schemeSelectArea->visible()) {
     m_focusRing.push_back({m_schemeSelectArea, [this]() { toggleSchemeMenu(); }});
   }
 
-  if (m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr) {
+  if (m_firmwareButton != nullptr && m_firmwareButton->inputArea() != nullptr && m_firmwareButton->visible()) {
     m_focusRing.push_back({m_firmwareButton->inputArea(), []() { power::rebootToFirmwareSetup(); }});
   }
-  if (m_rebootButton != nullptr && m_rebootButton->inputArea() != nullptr) {
+  if (m_rebootButton != nullptr && m_rebootButton->inputArea() != nullptr && m_rebootButton->visible()) {
     m_focusRing.push_back({m_rebootButton->inputArea(), []() { power::reboot(); }});
   }
-  if (m_shutdownButton != nullptr && m_shutdownButton->inputArea() != nullptr) {
+  if (m_shutdownButton != nullptr && m_shutdownButton->inputArea() != nullptr && m_shutdownButton->visible()) {
     m_focusRing.push_back({m_shutdownButton->inputArea(), []() { power::powerOff(); }});
   }
 
@@ -2340,10 +2373,28 @@ void GreeterSurface::layoutPowerButtons(float ox, float oy, float sw, float sh) 
     return;
   }
 
+  // Handle hidden position
+  if (m_powerButtonsPosition == "hidden") {
+    m_shutdownButton->setVisible(false);
+    m_rebootButton->setVisible(false);
+    if (m_firmwareButton != nullptr) {
+      m_firmwareButton->setVisible(false);
+    }
+    return;
+  }
+
   const float size = Style::controlHeight();
   const float margin = Style::spaceLg();
   const float gap = Style::spaceSm();
-  const float bottom = oy + sh - size - margin;
+
+  // Determine anchor position based on config
+  float y;
+  if (m_powerButtonsPosition == "top-left" || m_powerButtonsPosition == "top-right") {
+    y = oy + margin;
+  } else {
+    // Default: bottom-left or bottom-right
+    y = oy + sh - size - margin;
+  }
 
   const auto place = [&](Button* btn, float x) {
     if (btn == nullptr) {
@@ -2352,7 +2403,7 @@ void GreeterSurface::layoutPowerButtons(float ox, float oy, float sw, float sh) 
     btn->setVisible(true);
     btn->setRadius(size * 0.5f);
     btn->setSize(size, size);
-    btn->setPosition(x, bottom);
+    btn->setPosition(x, y);
     btn->layout(*renderer);
     if (Glyph* glyph = btn->glyph()) {
       (void)glyph->measure(*renderer);
@@ -2367,13 +2418,27 @@ void GreeterSurface::layoutPowerButtons(float ox, float oy, float sw, float sh) 
     }
   };
 
-  float x = ox + sw - size - margin;
-  place(m_shutdownButton, x);
-  x -= size + gap;
-  place(m_rebootButton, x);
-  if (m_firmwareButton != nullptr) {
+  // Determine horizontal placement: right-aligned (default) or left-aligned
+  if (m_powerButtonsPosition == "bottom-left" || m_powerButtonsPosition == "top-left") {
+    // Left-aligned: firmware → reboot → shutdown (left to right)
+    float x = ox + margin;
+    if (m_firmwareButton != nullptr) {
+      place(m_firmwareButton, x);
+      x += size + gap;
+    }
+    place(m_rebootButton, x);
+    x += size + gap;
+    place(m_shutdownButton, x);
+  } else {
+    // Right-aligned (default): shutdown → reboot → firmware (right to left)
+    float x = ox + sw - size - margin;
+    place(m_shutdownButton, x);
     x -= size + gap;
-    place(m_firmwareButton, x);
+    place(m_rebootButton, x);
+    if (m_firmwareButton != nullptr) {
+      x -= size + gap;
+      place(m_firmwareButton, x);
+    }
   }
 }
 
@@ -2664,6 +2729,10 @@ bool GreeterSurface::handleNavigationKey(std::uint32_t sym, std::uint32_t utf32,
     return true;
   }
   if (KeySymbol::isF7(sym)) {
+    // Don't respond if the scheme selector is hidden
+    if (m_schemeSelectorPosition == "hidden") {
+      return true;
+    }
     if (m_schemeMenuOpen) {
       closeMenusAndRestoreFocus();
     } else {

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -237,6 +237,9 @@ private:
   bool m_wallpaperDirty = false;
   bool m_hasSyncedWallpaper = false;
   bool m_hideLogo = false;
+  // UI element positioning: "hidden", "bottom-left", "bottom-right", "top-left", "top-right"
+  std::string m_powerButtonsPosition;
+  std::string m_schemeSelectorPosition;
   std::chrono::steady_clock::time_point m_lastAnimTick{};
   bool m_animTickInitialized = false;
   bool m_inInputDispatch = false;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds `appearance.power_buttons_position` and `appearance.scheme_selector_position` to `greeter.toml`. Both accept `"hidden"`, `"bottom-left"`, `"bottom-right"`, `"top-left"`, and `"top-right"`. Defaults match current behavior: power buttons at `"bottom-right"`, scheme selector at `"top-right"`.

Keyboard focus ring and the `F7` shortcut now respect hidden state, preventing interaction with invisible elements.

## Motivation

Pet peeve. Depending on wallpaper, relevant content stays behind the buttons and might look hideous.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

N/A

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Built with `just build-release` and tested under greetd. Verified:
- `"hidden"` correctly hides elements and removes them from keyboard focus
- `"bottom-left"`, `"top-left"`, `"top-right"`, `"bottom-right"` position correctly
- Defaults work when keys are omitted from `greeter.toml`
- `F7` shortcut does not open scheme menu when selector is hidden

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested under greetd (real login flow)
- [ ] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [ ] Tested on NixOS (`programs.noctalia-greeter`)
- [ ] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

Before:
<img width="3552" height="2003" alt="noctalia-greeter-PR01" src="https://github.com/user-attachments/assets/fc22ca7c-d356-4dbe-aabf-0be2d9d572db" />
<img width="293" height="216" alt="noctalia-greeter-PR02" src="https://github.com/user-attachments/assets/81cdbc60-28c0-4fae-94d0-664b381a53e2" />

After:
with:
```toml
[appearance]
hide_logo = true
power_buttons_position = "top-right"
scheme_selector_position = "hidden"
```
<img width="3323" height="1881" alt="noctalia-greeter-PR03" src="https://github.com/user-attachments/assets/164d09c7-7d01-4930-8ebe-c6201a462dcc" />
<img width="249" height="217" alt="noctalia-greeter-PR04" src="https://github.com/user-attachments/assets/80f97947-a0de-496e-99e7-ba59ff6e2a23" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `AGENTS.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [x] I will update end-user documentation in [noctalia-docs](https://github.com/noctalia-dev/noctalia-docs) after merge, or this PR does not change user-facing configuration or behavior.
- [x] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

New config keys follow the existing `hide_logo` precedent (declarative only in `greeter.toml`, not in `sync.toml`). no changes to noctalia shell sync are needed — these are purely admin configuration options.