### PR TITLE
fix(greeter): select scheme dropdown had upward hardcoded

### DIFF
--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -3380,9 +3380,11 @@ void GreeterSurface::rebuildSchemeMenu() {
   if (!m_schemeMenuOpen || m_schemeNames.empty()) {
     return;
   }
+  // Open upward when selector is at the bottom, downward otherwise
+  const bool upward = m_schemeSelectorPosition == "bottom-left" || m_schemeSelectorPosition == "bottom-right";
   buildMenu(
       m_schemeNames, m_selectedScheme, m_schemeSelectBox,
-      /*upward=*/false,
+      /*upward=*/upward,
       /*rightAlign=*/true, /*zBase=*/60, m_schemeMenuPanel, m_schemeMenuRows, m_schemeMenuLabels, m_schemeMenuAreas,
       [this](std::size_t i) { selectScheme(i); }
   );


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

The scheme selector dropdown now opens upward when the selector is positioned at the bottom (`bottom-left` or `bottom-right`), and downward otherwise.

## Motivation

<!-- What problem does this solve? -->

When the scheme selector is at the bottom of the screen, the dropdown menu would render off-screen below it. Opening upward keeps the menu visible and accessible.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
N/A

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

<img width="2088" height="1768" alt="noctalia-greeter-PR05" src="https://github.com/user-attachments/assets/e0f068c2-0d35-47b4-b9a1-f26686fb0f5d" />

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested under greetd (real login flow)
- [ ] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [ ] Tested on NixOS (`programs.noctalia-greeter`)
- [ ] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `AGENTS.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I will update end-user documentation in [noctalia-docs](https://github.com/noctalia-dev/noctalia-docs) after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

Depends on `appearance.power_buttons_position` and `appearance.scheme_selector_position` config keys from the previous PR.

Will update docs later today.