### PR TITLE
Add native_optimizations build option allowing portable release builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ build: configure
 
 # Configure release build dir
 configure-release:
-  meson setup build-release --buildtype=release --reconfigure
+  meson setup build-release --buildtype=release -Dnative_optimizations=true --reconfigure
 
 # Release build
 build-release: configure-release

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,6 @@ cpp = meson.get_compiler('cpp')
 
 if get_option('buildtype') == 'release'
   add_project_arguments(
-    '-march=native', '-mtune=native',
     '-fomit-frame-pointer', '-ffunction-sections', '-fdata-sections',
     language: ['c', 'cpp'],
   )
@@ -22,6 +21,10 @@ if get_option('buildtype') == 'release'
     '-Wl,--gc-sections', '-Wl,--as-needed',
     language: ['c', 'cpp'],
   )
+endif
+
+if get_option('native_optimizations')
+  add_project_arguments('-march=native', '-mtune=native', language: ['c', 'cpp'])
 endif
 
 wayland_client_dep = dependency('wayland-client')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'native_optimizations',
+  type: 'boolean',
+  value: false,
+  description: 'Optimize for the build machine CPU; output may not be portable',
+)


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Add a separate `native_optimizations` build option for arch=native and tune=native instead of bundling it together with release buildtype.

## Motivation

Allows package maintainers to build noctalia-greeter with `--buildtype=release` to produce a portable build, and this follows what `meson.build` does in noctalia itself. 

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Testing

Ran `just build-release` which now takes `-Dnative_optimizations=true`. Let me know if the change in Justfile is acceptable since non-portable builds were produced by default up to this point.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested under greetd (real login flow)
- [x] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [ ] Tested on NixOS (`programs.noctalia-greeter`)
- [ ] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](docs/user/) when this PR changes user-visible behavior or configuration, or this PR does not require documentation changes.
- [x] I used the existing canonical names for config keys, paths, and identifiers.
