### PR TITLE
fix(nixos): expose configured sessions to greeter

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -114,7 +114,11 @@ in
 
         services.greetd = {
           enable = lib.mkDefault true;
-          settings.default_session.command = lib.mkDefault "${cfg.package}/bin/noctalia-greeter-session -- ${cfg.greeter-args}";
+          settings.default_session.command = lib.mkDefault (
+            "${lib.getExe' pkgs.coreutils "env"} "
+            + "XDG_DATA_DIRS=${config.services.displayManager.sessionData.desktops}/share "
+            + "${cfg.package}/bin/noctalia-greeter-session -- ${cfg.greeter-args}"
+          );
         };
 
         services.accounts-daemon.enable = lib.mkDefault true;


### PR DESCRIPTION
## Summary

Expose the configured NixOS Wayland sessions to Noctalia Greeter.

## Motivation

NixOS keeps display-manager session entries in a generated aggregate that is not linked into the normal system profile. As a result, the greeter cannot discover configured sessions through `/run/current-system/sw/share/wayland-sessions`.

Prefix the greetd command with `XDG_DATA_DIRS` pointing directly at `services.displayManager.sessionData.desktops`, using the packaged `env` executable.

## Type of Change

- [x] Bug fix
- [x] Build / packaging

## Testing

- `nix develop -c just format`
- Evaluated a NixOS configuration with a synthetic Wayland session and verified that the generated greetd command contains the exact session aggregate path.

## Manual Coverage

- [ ] Tested under greetd (real login flow)
- [ ] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [ ] Tested on NixOS (`programs.noctalia-greeter`)
- [ ] Tested with a pinned `[output].name`
- [ ] Tested with custom `[output].layout` / `[output].transforms`

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](docs/user/) when this PR changes user-visible behavior or configuration, or this PR does not require documentation changes.
- [x] I used the existing canonical names for config keys, paths, and identifiers.
