### PR TITLE
fix(compositor): map cursor to output so absolute input follows transform

### DIFF
--- a/src/compositor/noctalia_compositor.c
+++ b/src/compositor/noctalia_compositor.c
@@ -1433,6 +1433,10 @@ static void choose_outputs(struct greeter_server* server) {
     wlr_log(WLR_INFO, "greeter pinned output: %s", pinned->wlr_output->name);
   }
 
+  // Mapping also lets wlroots apply the output transform to absolute input
+  // events before they reach the cursor listeners. Re-evaluate on hotplug.
+  wlr_cursor_map_to_output(server->cursor, pinned != NULL && pinned->active ? pinned->wlr_output : NULL);
+
   wl_list_for_each(output, &server->outputs, link) {
     if (output->view != NULL && output->view->mapped) {
       configure_view(output->view);


### PR DESCRIPTION
The compositor applies wl_output_transform when enabling outputs, but the cursor is never mapped to an output, so wlroots does not apply the output transform to absolute input events. On panels that require output.transforms (e.g. portrait-native tablets rotated to landscape), touchscreen taps land rotated/mirrored relative to the displayed UI.

Map the cursor to the pinned/active output whenever outputs are chosen, and re-evaluate on hotplug.

Fixes #114

<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Map the cursor to the pinned/active output in `choose_outputs()` with
`wlr_cursor_map_to_output()`, re-evaluated whenever outputs are (re)chosen.
This lets wlroots apply the output transform to absolute input events
before they reach the cursor listeners.

## Motivation

The compositor applies `wl_output_transform` when enabling outputs (#62),
but the cursor was never mapped to an output, so absolute input events are
interpreted in the untransformed coordinate space. On panels that require
`output.transforms` (e.g. portrait-native tablets rotated to landscape),
touchscreen taps land rotated/mirrored relative to the displayed UI:
tapping the visually top-left corner registers near the opposite corner.
Relative pointer and keyboard input are unaffected.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #114

## Testing

Built and verified on a Xiaomi Pad 5 (single built-in `DSI-1` panel,
portrait-native 1600×2560, `output.name = "DSI-1"`,
`output.transforms = "DSI-1:270"`, Adreno 640 / freedreno):

- Before: taps land at a 270° offset from the finger.
- After: taps hit the element under the finger.

Tested via the nixpkgs NixOS module (`services.displayManager.noctalia-greeter`)
against v1.3.1, whose `src/compositor/` is identical to current `main`.
Ran `clang-format --style=file` (v23.1.0) over the changed file — no diff.

## Manual Coverage

- [x] Tested under greetd (real login flow)
- [ ] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested with multiple monitors
- [ ] Tested appearance sync from Noctalia Shell (`Sync Now`)
- [x] Tested on NixOS (`programs.noctalia-greeter`)
- [x] Tested with a pinned `[output].name`
- [x] Tested with custom `[output].layout` / `[output].transforms`

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated user-facing documentation in [`docs/user/`](docs/user/) when this PR changes user-visible behavior or configuration, or this PR does not require documentation changes.
- [x] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes

The mapping is re-evaluated on every `choose_outputs()` call (including
hotplug), so the cursor stays pinned to the intended output across monitor
changes. Tablet/pen input will take the same path once tablet events are
handled (separate change).

