### PR TITLE
greeter: animated WebP background

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ if not cc.has_header('stb/stb_image_resize2.h')
 endif
 
 libwebp_dep = dependency('libwebp', required: true)
+libwebpdemux_dep = dependency('libwebpdemux', required: true)
 
 # ── Wayland protocol generation ───────────────────────────────────────────────
 wayland_scanner    = find_program('wayland-scanner')
@@ -162,6 +163,7 @@ _greeter_sources = files(
   'src/greeter/greeter_preferences.cpp',
   'src/greeter/greeter_sessions.cpp',
   'src/greeter/greeter_surface.cpp',
+  'src/greeter/animated_webp_background.cpp',
   'src/greeter/greeter_window.cpp',
   'src/greeter/logind_resume.cpp',
   'src/greeter/power_actions.cpp',
@@ -197,6 +199,7 @@ noctalia_greeter_executable = executable('noctalia-greeter',
     gobject_dep,
     gio_dep,
     libwebp_dep,
+    libwebpdemux_dep,
     nlohmann_dep,
     tomlplusplus_dep,
   ],

--- a/src/greeter/animated_webp_background.cpp
+++ b/src/greeter/animated_webp_background.cpp
@@ -1,0 +1,220 @@
+#include "greeter/animated_webp_background.h"
+
+#include "core/log.h"
+#include "render/core/image_decoder.h" // kMaxWebpCanvasBytes
+#include "render/core/texture_manager.h"
+#include "render/render_context.h"
+#include "util/file_utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <utility>
+#include <webp/decode.h>
+#include <webp/demux.h>
+
+namespace {
+
+  constexpr Logger kLog("greeter");
+
+  // Floor on a frame's on-screen duration. Guards a 0ms (or malformed negative)
+  // inter-frame delta from advancing every tick, and keeps the effective cadence
+  // at or under one display refresh.
+  constexpr int kMinFrameDurationMs = 16;
+
+  // Cap on how many frames a single advance() may decode, so a large delta after
+  // a long pause (e.g. the greeter output being blanked and woken) cannot decode
+  // a whole clip in one tick; the backlog is dropped instead.
+  constexpr int kMaxFramesPerAdvance = 8;
+
+  // Reject the file before reading it all into memory: a multi-GB file would OOM
+  // the pre-auth greeter. A real 24fps 1080p clip is a few MB.
+  constexpr std::uint64_t kMaxWebpFileBytes = 64ULL * 1024 * 1024;
+
+  // Tighter than the still-image canvas cap: the animation decoder holds two full
+  // canvases plus a GPU texture, so keep the canvas well under GL texture limits.
+  constexpr std::uint64_t kMaxAnimatedCanvasBytes = 64ULL * 1024 * 1024;
+
+} // namespace
+
+void AnimatedWebpBackground::DecoderDeleter::operator()(WebPAnimDecoder* decoder) const noexcept {
+  WebPAnimDecoderDelete(decoder);
+}
+
+AnimatedWebpBackground::~AnimatedWebpBackground() { stop(); }
+
+AnimatedWebpBackground::StartResult
+AnimatedWebpBackground::start(RenderContext& ctx, const std::string& path, std::function<void()> onFailure) {
+  stop();
+
+  std::error_code sizeEc;
+  const auto fileSize = std::filesystem::file_size(path, sizeEc);
+  if (sizeEc || fileSize == 0) {
+    return StartResult::TransientFailure; // missing/unreadable now; may appear later
+  }
+  if (fileSize > kMaxWebpFileBytes) {
+    kLog.warn("WebP \"{}\" is {} bytes, over the cap; ignoring", path, static_cast<std::uint64_t>(fileSize));
+    return StartResult::NotAnimated;
+  }
+
+  std::vector<std::uint8_t> bytes = FileUtils::readBinaryFile(path);
+  if (bytes.empty()) {
+    return StartResult::TransientFailure; // missing/unreadable now; may appear later
+  }
+  if (bytes.size() > kMaxWebpFileBytes) {
+    return StartResult::NotAnimated; // grew past the cap between stat and read
+  }
+
+  WebPBitstreamFeatures features;
+  if (WebPGetFeatures(bytes.data(), bytes.size(), &features) != VP8_STATUS_OK) {
+    return StartResult::NotAnimated; // not a WebP
+  }
+  if (features.has_animation == 0) {
+    return StartResult::NotAnimated; // still WebP -> static path
+  }
+  // Reject an oversized canvas BEFORE WebPAnimDecoderNew: a VP8X header can
+  // declare dimensions independent of the (small) file size, and the decoder
+  // would allocate the full canvas twice up front (an OOM vector).
+  if (features.width <= 0
+      || features.height <= 0
+      || static_cast<std::uint64_t>(features.width) * static_cast<std::uint64_t>(features.height) * 4
+          > kMaxAnimatedCanvasBytes) {
+    kLog.warn("animated WebP \"{}\" canvas {}x{} exceeds size cap; ignoring", path, features.width, features.height);
+    return StartResult::NotAnimated;
+  }
+
+  WebPAnimDecoderOptions options;
+  if (WebPAnimDecoderOptionsInit(&options) == 0) {
+    return StartResult::TransientFailure;
+  }
+  options.color_mode = MODE_RGBA; // non-premultiplied RGBA8, matches TextureDataFormat::Rgba
+  options.use_threads = 0;
+
+  // The decoder references the encoded bytes without copying them, so they must
+  // outlive it. Build decoder + bytes as locals and commit to members only once
+  // every probe passes (moving a vector keeps the same buffer the decoder holds).
+  const WebPData webpData{.bytes = bytes.data(), .size = bytes.size()};
+  std::unique_ptr<WebPAnimDecoder, DecoderDeleter> decoder(WebPAnimDecoderNew(&webpData, &options));
+  if (!decoder) {
+    kLog.warn("failed to open WebP animation \"{}\"", path);
+    return StartResult::NotAnimated;
+  }
+
+  WebPAnimInfo info;
+  if (WebPAnimDecoderGetInfo(decoder.get(), &info) == 0 || info.canvas_width == 0 || info.canvas_height == 0) {
+    kLog.warn("failed to read WebP animation info \"{}\"", path);
+    return StartResult::NotAnimated;
+  }
+
+  m_ctx = &ctx;
+  m_path = path;
+  m_bytes = std::move(bytes);
+  m_decoder = std::move(decoder);
+  m_width = static_cast<int>(info.canvas_width);
+  m_height = static_cast<int>(info.canvas_height);
+  m_prevTimestampMs = 0;
+  m_currentFrameDurationMs = kMinFrameDurationMs;
+  m_accumulatedMs = 0.0F;
+  m_onFailure = std::move(onFailure);
+
+  m_texture = m_ctx->textureManager().createEmpty(m_width, m_height, TextureDataFormat::Rgba, TextureFilter::Linear);
+  if (!m_texture.id.valid()) {
+    stop();
+    return StartResult::TransientFailure; // GPU allocation failed; may succeed later
+  }
+
+  kLog.info("streaming animated WebP background \"{}\" ({}x{}, {} frames)", path, m_width, m_height, info.frame_count);
+
+  // Upload the first frame immediately so there is no blank flash before the
+  // render loop starts advancing us.
+  if (!decodeAndUploadNext()) {
+    stop();
+    return StartResult::NotAnimated; // frame 0 is undecodable -> treat as broken/still
+  }
+  return StartResult::Started;
+}
+
+void AnimatedWebpBackground::stop() {
+  if (m_texture.id.valid() && m_ctx != nullptr) {
+    m_ctx->textureManager().unload(m_texture);
+  }
+  m_texture = {};
+  m_decoder.reset();
+  m_bytes.clear();
+  m_bytes.shrink_to_fit();
+  m_onFailure = nullptr;
+  m_ctx = nullptr;
+  m_path.clear();
+  m_width = 0;
+  m_height = 0;
+  m_prevTimestampMs = 0;
+  m_currentFrameDurationMs = 0;
+  m_accumulatedMs = 0.0F;
+}
+
+bool AnimatedWebpBackground::advance(float deltaMs) {
+  if (!m_decoder) {
+    return false;
+  }
+  m_accumulatedMs += deltaMs;
+  bool uploaded = false;
+  for (int decoded = 0; m_accumulatedMs >= static_cast<float>(m_currentFrameDurationMs); ++decoded) {
+    if (decoded >= kMaxFramesPerAdvance) {
+      m_accumulatedMs = 0.0F; // drop the backlog after a long pause
+      break;
+    }
+    m_accumulatedMs -= static_cast<float>(m_currentFrameDurationMs);
+    if (!decodeAndUploadNext()) {
+      failStop();
+      return uploaded;
+    }
+    uploaded = true;
+  }
+  return uploaded;
+}
+
+bool AnimatedWebpBackground::decodeAndUploadNext() {
+  if (m_ctx == nullptr || !m_decoder) {
+    return false;
+  }
+
+  // Loop: rewind to the first frame once the clip is exhausted.
+  if (WebPAnimDecoderHasMoreFrames(m_decoder.get()) == 0) {
+    WebPAnimDecoderReset(m_decoder.get());
+    m_prevTimestampMs = 0;
+  }
+
+  std::uint8_t* frame = nullptr;
+  int timestampMs = 0;
+  if (WebPAnimDecoderGetNext(m_decoder.get(), &frame, &timestampMs) == 0 || frame == nullptr) {
+    return false;
+  }
+  m_ctx->textureManager().updateSubImage(m_texture, frame, 0, 0, m_width, m_height, TextureDataFormat::Rgba);
+
+  // The returned timestamp is the frame's cumulative END time; the delta from the
+  // previous end is how long this frame should remain on screen.
+  const int duration = timestampMs - m_prevTimestampMs;
+  m_prevTimestampMs = timestampMs;
+  m_currentFrameDurationMs = std::max(duration, kMinFrameDurationMs);
+  return true;
+}
+
+int AnimatedWebpBackground::millisUntilNextFrame() const noexcept {
+  if (!m_decoder) {
+    return -1;
+  }
+  const float remaining = static_cast<float>(m_currentFrameDurationMs) - m_accumulatedMs;
+  return remaining <= 0.0F ? 0 : static_cast<int>(std::ceil(remaining));
+}
+
+void AnimatedWebpBackground::failStop() {
+  kLog.warn("WebP animation decode failed, stopping playback \"{}\"", m_path);
+  // Capture the callback before stop() clears it, then notify the owner so it can
+  // drop the now-deleted texture and fall back to a static background.
+  auto onFailure = m_onFailure;
+  stop();
+  if (onFailure) {
+    onFailure();
+  }
+}

--- a/src/greeter/animated_webp_background.h
+++ b/src/greeter/animated_webp_background.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "render/core/texture_handle.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+class RenderContext;
+struct WebPAnimDecoder;
+
+/// Streams an animated WebP onto a single, reused GPU texture. Unlike the shell
+/// lockscreen, the greeter has no timer: playback is advanced by the per-frame
+/// render tick (advance()), decoding and uploading the next frame in place via
+/// TextureManager::updateSubImage. Video memory stays bounded to roughly one
+/// frame regardless of clip length. Used as the greeter background when the
+/// configured wallpaper path is an animated WebP.
+///
+/// Single-threaded by design: all work runs on the render/main thread.
+class AnimatedWebpBackground {
+public:
+  enum class StartResult {
+    NotAnimated,      ///< not a WebP, a still WebP, or an oversized canvas -> use the static path (do not retry)
+    TransientFailure, ///< a readable animated WebP but a transient error (e.g. unreadable file) -> retry later
+    Started,          ///< streaming; first frame already uploaded
+  };
+
+  AnimatedWebpBackground() = default;
+  ~AnimatedWebpBackground();
+
+  AnimatedWebpBackground(const AnimatedWebpBackground&) = delete;
+  AnimatedWebpBackground& operator=(const AnimatedWebpBackground&) = delete;
+
+  /// Begins playback if `path` is an animated WebP within the canvas-size cap,
+  /// uploading the first frame immediately. `onFailure` fires once if a later
+  /// decode error stops playback, so the owner can drop the (now deleted)
+  /// texture and fall back to a static background.
+  StartResult start(RenderContext& ctx, const std::string& path, std::function<void()> onFailure);
+
+  /// Full teardown: releases the GPU texture and frees the decoder. Safe when
+  /// inactive. Must run while `ctx` (from start) is still valid.
+  void stop();
+
+  /// Advances playback by `deltaMs` of elapsed frame time, decoding and
+  /// uploading the next frame(s) whose display duration has elapsed and looping
+  /// at the end. Returns true if a new frame was uploaded this call, so the owner
+  /// can mark its node dirty. No-op (returns false) when inactive.
+  bool advance(float deltaMs);
+
+  [[nodiscard]] bool active() const noexcept { return m_decoder != nullptr; }
+  [[nodiscard]] const std::string& path() const noexcept { return m_path; }
+  [[nodiscard]] TextureHandle texture() const noexcept { return m_texture; }
+
+  /// Milliseconds until the next frame is due (0 if due now), or -1 when inactive.
+  /// Lets the owner sleep exactly until the next frame instead of polling.
+  [[nodiscard]] int millisUntilNextFrame() const noexcept;
+
+private:
+  struct DecoderDeleter {
+    void operator()(WebPAnimDecoder* decoder) const noexcept;
+  };
+
+  bool decodeAndUploadNext();
+  void failStop();
+
+  RenderContext* m_ctx = nullptr;
+  std::string m_path;
+  std::vector<std::uint8_t> m_bytes; // owns the encoded data the decoder references
+  std::unique_ptr<WebPAnimDecoder, DecoderDeleter> m_decoder;
+  int m_width = 0;
+  int m_height = 0;
+  int m_prevTimestampMs = 0;        // cumulative end time of the last decoded frame (libwebp semantics)
+  int m_currentFrameDurationMs = 0; // on-screen duration of the currently shown frame
+  float m_accumulatedMs = 0.0F;     // elapsed time banked toward the next frame
+  TextureHandle m_texture{};
+  std::function<void()> m_onFailure;
+};

--- a/src/greeter/greeter.cpp
+++ b/src/greeter/greeter.cpp
@@ -161,7 +161,24 @@ int Greeter::run(WaylandClient& client, const std::atomic<bool>& shutdownRequest
 
     const int repeatMs = client.repeatPollTimeoutMs();
     const int requestMs = m_greetdClient.requestPollTimeoutMs();
-    const int timeoutMs = repeatMs < 0 ? requestMs : requestMs < 0 ? repeatMs : std::min(repeatMs, requestMs);
+    int timeoutMs = repeatMs < 0 ? requestMs : requestMs < 0 ? repeatMs : std::min(repeatMs, requestMs);
+
+    // An animated wallpaper has no external frame clock (frame callbacks stall
+    // when the scene is otherwise idle, and nested backends never tick), so pace
+    // it from this loop: wake at roughly one frame interval while it plays.
+    bool animatingBackground = false;
+    for (auto& view : m_views) {
+      if (view.surface == nullptr) {
+        continue;
+      }
+      const int frameMs = view.surface->animationPollTimeoutMs();
+      if (frameMs < 0) {
+        continue;
+      }
+      animatingBackground = true;
+      const int clamped = std::max(frameMs, 4); // floor to avoid a busy loop
+      timeoutMs = timeoutMs < 0 ? clamped : std::min(timeoutMs, clamped);
+    }
 
     while (wl_display_prepare_read(display) != 0) {
       if (wl_display_dispatch_pending(display) < 0) {
@@ -227,6 +244,18 @@ int Greeter::run(WaylandClient& client, const std::atomic<bool>& shutdownRequest
     if (wl_display_dispatch_pending(display) < 0) {
       logWaylandDispatchError(display, "dispatch_pending");
       return 1;
+    }
+
+    // Drive the animated background from the main loop: advance on wall-clock
+    // time and repaint only when a new frame was actually decoded, so it renders
+    // at the clip's rate rather than the display's. Safe here (not inside
+    // prepareFrame), so requestRedraw cannot recurse.
+    if (animatingBackground) {
+      for (auto& view : m_views) {
+        if (view.surface != nullptr && view.surface->advanceAnimation() && view.window != nullptr) {
+          view.window->requestRedraw();
+        }
+      }
     }
   }
 

--- a/src/greeter/greeter_surface.cpp
+++ b/src/greeter/greeter_surface.cpp
@@ -178,6 +178,7 @@ GreeterSurface::GreeterSurface() = default;
 
 GreeterSurface::~GreeterSurface() {
   if (m_renderContext != nullptr) {
+    m_animatedBackground.stop();
     if (m_brandLogoTexture.id != 0) {
       m_renderContext->textureManager().unload(m_brandLogoTexture);
     }
@@ -1953,8 +1954,115 @@ void GreeterSurface::syncHeaderUserAvatar(
   m_headerUserAvatar->setVisible(true);
 }
 
+bool GreeterSurface::pathLooksLikeWebp(const std::string& path) {
+  if (path.size() < 5) {
+    return false;
+  }
+  std::string suffix = path.substr(path.size() - 5);
+  for (char& c : suffix) {
+    if (c >= 'A' && c <= 'Z') {
+      c = static_cast<char>(c - 'A' + 'a');
+    }
+  }
+  return suffix == ".webp";
+}
+
+// Streams the wallpaper as an animated WebP when the configured path is one.
+// Returns true when the animated background owns the wallpaper node; false tells
+// the caller to fall through to the static image/color path.
+bool GreeterSurface::applyAnimatedWallpaper() {
+  const bool wantAnimated = pathLooksLikeWebp(m_wallpaperPath);
+
+  if (m_animatedBackground.active() && (!wantAnimated || m_animatedBackground.path() != m_wallpaperPath)) {
+    m_animatedBackground.stop();
+    m_wallpaper->setTextures({}, {}, 0.0f, 0.0f, 0.0f, 0.0f);
+  }
+
+  if (!wantAnimated || m_renderContext == nullptr) {
+    return false;
+  }
+  if (m_animatedBackground.active() && m_animatedBackground.path() == m_wallpaperPath) {
+    return true; // already streaming this clip
+  }
+  if (m_animatedBackgroundRuledOut == m_wallpaperPath) {
+    return false; // known still/broken WebP -> static path
+  }
+
+  if (m_wallpaperTexture.id != 0) {
+    m_renderContext->textureManager().unload(m_wallpaperTexture);
+    m_wallpaperTexture = {};
+  }
+
+  switch (m_animatedBackground.start(*m_renderContext, m_wallpaperPath, [this] { onAnimatedBackgroundFailed(); })) {
+  case AnimatedWebpBackground::StartResult::Started:
+    m_animatedBackgroundRuledOut.clear();
+    m_bgTickInitialized = false; // restart the pacing clock so a long gap does not skip frames
+    onAnimatedBackgroundFrame(); // bind the first frame
+    m_wallpaper->setTransition(WallpaperTransition::Fade, 0.0f, TransitionParams{});
+    m_wallpaper->setFillMode(m_wallpaperFillMode);
+    m_wallpaper->setFillColor(m_wallpaperFillColor);
+    return true;
+  case AnimatedWebpBackground::StartResult::NotAnimated:
+    m_animatedBackgroundRuledOut = m_wallpaperPath; // still/broken WebP -> static path, do not re-probe
+    return false;
+  case AnimatedWebpBackground::StartResult::TransientFailure:
+    return false; // unreadable right now; fall through to the static path
+  }
+  return false;
+}
+
+// Rebinds the node to the streaming texture (idempotent once the id is stable).
+bool GreeterSurface::advanceAnimation() {
+  if (!m_animatedBackground.active()) {
+    return false;
+  }
+  const auto now = std::chrono::steady_clock::now();
+  if (!m_bgTickInitialized) {
+    m_lastBgTick = now;
+    m_bgTickInitialized = true;
+    return false;
+  }
+  const float deltaMs = std::chrono::duration<float, std::milli>(now - m_lastBgTick).count();
+  m_lastBgTick = now;
+  if (deltaMs <= 0.0f) {
+    return false;
+  }
+  const bool uploaded = m_animatedBackground.advance(deltaMs);
+  if (uploaded && m_wallpaper != nullptr) {
+    m_wallpaper->markPaintDirty();
+  }
+  return uploaded;
+}
+
+void GreeterSurface::onAnimatedBackgroundFrame() {
+  if (m_wallpaper == nullptr) {
+    return;
+  }
+  const TextureHandle texture = m_animatedBackground.texture();
+  m_wallpaper->setTextures(
+      texture.id, {}, static_cast<float>(texture.width), static_cast<float>(texture.height), 0.0f, 0.0f
+  );
+}
+
+// The streaming decoder stopped on a mid-clip error; drop the now-stale node
+// texture and fall back to the static path.
+void GreeterSurface::onAnimatedBackgroundFailed() {
+  // Playback stopped mid-clip (the streaming texture is already gone); clear the
+  // node so it falls back to the fill colour. This runs from advance() inside
+  // prepareFrame, so it must not trigger a synchronous redraw.
+  if (m_wallpaper != nullptr) {
+    m_wallpaper->setTextures({}, {}, 0.0f, 0.0f, 0.0f, 0.0f);
+  }
+  m_animatedBackgroundRuledOut = m_wallpaperPath;
+}
+
 void GreeterSurface::syncWallpaperTexture() {
   if (!m_wallpaperDirty || m_wallpaper == nullptr || m_renderContext == nullptr) {
+    return;
+  }
+
+  if (applyAnimatedWallpaper()) {
+    m_wallpaperDirty = false;
     return;
   }
 

--- a/src/greeter/greeter_surface.h
+++ b/src/greeter/greeter_surface.h
@@ -2,6 +2,7 @@
 
 #include "config/config_types.h"
 #include "greetd/greetd_client.h"
+#include "greeter/animated_webp_background.h"
 #include "greeter/appearance_config.h"
 #include "greeter/greeter_sessions.h"
 #include "render/animation/animation_manager.h"
@@ -76,6 +77,8 @@ public:
   [[nodiscard]] bool handleNavigationKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modifiers);
   void requestLayout();
   void requestRedraw();
+  [[nodiscard]] int animationPollTimeoutMs() const noexcept { return m_animatedBackground.millisUntilNextFrame(); }
+  bool advanceAnimation();
   void flushDeferredFrameRequests();
 
   void prepareFrame(std::uint32_t width, std::uint32_t height, bool needsLayout);
@@ -161,6 +164,10 @@ private:
   [[nodiscard]] bool isSyncedScheme(std::size_t schemeIndex) const;
   [[nodiscard]] std::optional<std::size_t> findSchemeIndex(std::string_view name) const;
   void syncWallpaperTexture();
+  [[nodiscard]] bool applyAnimatedWallpaper();
+  void onAnimatedBackgroundFrame();
+  void onAnimatedBackgroundFailed();
+  [[nodiscard]] static bool pathLooksLikeWebp(const std::string& path);
   void syncHeaderUserAvatar(class Renderer& renderer, float size, float panelX, float panelWidth, float headerY);
 
   // Nodes unregister animations while being destroyed, so the manager must
@@ -252,6 +259,8 @@ private:
   std::string m_loadedHeaderAvatarPath;
   std::string m_boundOutputName;
   std::string m_wallpaperPath;
+  AnimatedWebpBackground m_animatedBackground;
+  std::string m_animatedBackgroundRuledOut;
   WallpaperFillMode m_wallpaperFillMode = WallpaperFillMode::Crop;
   Color m_wallpaperFillColor = rgba(0.0f, 0.0f, 0.0f, 0.0f);
   bool m_wallpaperDirty = false;
@@ -262,6 +271,8 @@ private:
   std::string m_schemeSelectorPosition;
   std::chrono::steady_clock::time_point m_lastAnimTick{};
   bool m_animTickInitialized = false;
+  std::chrono::steady_clock::time_point m_lastBgTick{};
+  bool m_bgTickInitialized = false;
   bool m_inInputDispatch = false;
   bool m_inLayout = false;
   bool m_deferredLayoutRequest = false;

--- a/src/render/core/image_decoder.cpp
+++ b/src/render/core/image_decoder.cpp
@@ -35,6 +35,23 @@ namespace {
   }
 
   std::optional<DecodedRasterImage> decodeWebP(const std::uint8_t* data, std::size_t size, std::string* errorMessage) {
+    // A WebP (especially VP8X) can declare a canvas far larger than its file
+    // size; cap it before libwebp allocates the full RGBA canvas to avoid OOM.
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(data, size, &features) != VP8_STATUS_OK) {
+      if (errorMessage != nullptr)
+        *errorMessage = "libwebp: failed to read WebP header";
+      return std::nullopt;
+    }
+    if (features.width <= 0
+        || features.height <= 0
+        || static_cast<std::uint64_t>(features.width) * static_cast<std::uint64_t>(features.height) * 4
+            > kMaxWebpCanvasBytes) {
+      if (errorMessage != nullptr)
+        *errorMessage = "libwebp: WebP canvas exceeds size cap";
+      return std::nullopt;
+    }
+
     int width = 0, height = 0;
     std::uint8_t* rgba = WebPDecodeRGBA(data, size, &width, &height);
     if (rgba == nullptr) {

--- a/src/render/core/image_decoder.h
+++ b/src/render/core/image_decoder.h
@@ -6,6 +6,13 @@
 #include <string>
 #include <vector>
 
+// Upper bound on a WebP canvas we will decode, in RGBA bytes. A WebP VP8X header
+// can declare a canvas far larger than its (small) file size, and libwebp would
+// allocate the full canvas (twice, for animation) before any downstream check,
+// so an attacker-sized canvas is an OOM vector. 256 MiB (~8192x8192 RGBA) is far
+// above any real display while bounding the allocation.
+inline constexpr std::size_t kMaxWebpCanvasBytes = 256ULL * 1024 * 1024;
+
 struct DecodedRasterImage {
   std::vector<std::uint8_t> pixels;
   int width = 0;


### PR DESCRIPTION
> Draft: functionally complete and tested nested, but not yet dogfooded under real greetd, and a decode-efficiency rework is planned (see Additional Notes). Opening early to share the approach.

## Summary

Adds an animated WebP background for the greeter. When the configured wallpaper (`[appearance.wallpaper]` `path`) is an animated WebP, it plays and loops behind the login UI; a still image (or a still WebP) uses the existing static path unchanged.

`AnimatedWebpBackground` streams the clip onto a single reused GPU texture: one frame is decoded per main-loop tick and uploaded in place via `updateSubImage`, so video memory stays bounded to roughly one frame regardless of clip length. The greeter has no vblank clock (it renders on demand, and a nested backend never ticks), so playback is paced from the existing `poll()` main loop at the clip's own frame rate, and the loop repaints only when a new frame has decoded.

Uses the WebP libraries already in the tree: `libwebp` was linked; this adds `libwebpdemux` (the `WebPAnimDecoder` API, same upstream package).

## Motivation

Lets a greeter background match an animated lock/desktop wallpaper without adding a video stack: it reuses libwebp. The streaming design keeps memory flat, so a long clip costs the same memory as a short one.

## Type of Change

- [x] New feature

## Testing

- `meson compile -C build noctalia-greeter` and a release build: both clean, no new warnings.
- Ran nested inside a Wayland session (compositor with `WAYLAND_DISPLAY` set, `GREETD_SOCK` unset): the greeter renders and the background streams and loops (verified the rendered region changes over time and by screenshot), no crash. Not yet run under real greetd.
- Self-reviewed, plus an adversarial correctness/security pass over the diff.

## Manual Coverage

- [x] Tested with `just run` / `just run-local` (dev compositor)
- [ ] Tested under greetd (real login flow)
- [ ] Tested with multiple monitors

## Screenshots / Videos

A screen recording will be added.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md` and `README.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I updated user-facing documentation in [`docs/user/`](docs/user/) when this PR changes user-visible behavior or configuration, or this PR does not require documentation changes.
- [x] I used the existing canonical names for config keys, paths, and identifiers.

## Additional Notes

Known follow-ups (why this is a draft):

- **Decode efficiency.** It currently decodes and uploads the full canvas each frame, which is the cost driver for a full-resolution clip. Planned rework: pre-decode all frames to GPU textures when they fit a VRAM budget (playback becomes a texture swap), otherwise decode and upload only each frame's dirty rectangle via `WebPDemux`/`WebPIterator` with dispose/blend compositing. The clip's per-frame dirty coverage is often well under the full canvas, so this should roughly halve the cost while keeping any clip length.
- **Pause when not presented.** Advance should be gated on frame-callback acknowledgment so an off/obscured display does not keep decoding.
- Documentation for the animated-wallpaper behavior is not written yet.
